### PR TITLE
Attempt to speed up PublicSuffixService#parse 

### DIFF
--- a/test/public_suffix_service/rule_list_test.rb
+++ b/test/public_suffix_service/rule_list_test.rb
@@ -16,6 +16,28 @@ class PublicSuffixService::RuleListTest < Test::Unit::TestCase
     assert_equal 0, @list.length
   end
 
+  def test_initialize_create_index_when_empty
+    assert_equal({}, @list.buckets)
+  end
+
+  def test_find__with_index
+    @list = PublicSuffixService::RuleList.parse(<<EOS)
+// com : http://en.wikipedia.org/wiki/.com
+com
+
+// uk : http://en.wikipedia.org/wiki/.uk
+*.uk
+*.sch.uk
+!bl.uk
+!british-library.uk
+EOS
+
+    assert !@list.buckets.empty?
+    assert_equal [1,2,3,4], @list.buckets.delete('uk')
+    assert_equal [0], @list.buckets.delete('com')
+    assert @list.buckets.empty?
+  end
+
 
   def test_equality_with_self
     list = PublicSuffixService::RuleList.new


### PR DESCRIPTION
Hi,

I tried using public_suffix_service parsing many +100 per sec domains in a live app and I had to plug it off it was slowing me down a lot.

After poking around a little with ruby-prof I figured the problem was (at least in part) RuleList#select doing a very large Array#select operation for every single domain I was parsing. 

In the last commit I tried adding an 'index' (just a hash) to RuleList to make select only try a subset of the rules, for instance if the domain I'm parsins is host.py RuleList#select would only try to use Rule#match? on the rules where Rule#label.first is 'py' ( does that make sense or am I leaving out possible matches?).

Also I'm assuming the rules are ordered, is that a safe assumption? 

In any case a quick benchmark gives me this results:
- Original gem
  ruby benchmark.rb 
  2.270000   0.030000   2.300000 (  2.427320)
- Ater commit
  ruby benchmark.rb 
  0.100000   0.010000   0.110000 (  0.112830)

Benchmark code

<pre>
arr = %w{  yahoo.com sexyshoeskicks.com bridal-accessories.beautiesedge.com p90xkicks.com muscleandfitnessmagazine.net hispavista.com yandex.ua naturalspindancewear.com lymediseasereview.com howtojumphigherinbasketball.info jumpinganaconda.com grantgift.com pspmemoryshop.com thx.ly eluxury-brands.com forum.ea.com cosmeticvaginalsurgery.blog.com time-synchronisation.co.uk downcomforterfill.com bikemotorcycleparts.com northcapitolstreet.com trafficsiphonreviewx.com snmaster-idx.com astore.amazon.com grants-for-single-mothers.org          welcomecareers.com womenwalkingshoe.org  platformwedge.org    leontina23samiko.wiki.zoho.com          zahngold-verkaufen.info  ipadunlockfree.com ipadreviewss.blogspot.com          cellphoneaccessoriestoday.com thebes7.com bestbodycleanse.net  louisvuittonbagmall.com 1511.cn          weddingstart.net fujifilm.quadzynergy.com  babiespregnancy.com concursocnn.com.br  eeden.org          hobbynow.bloggzor.com          morethanthegames.co.uk          society-guide.com          grandtheftmario.com          usahouses.co.cc          nice-items.com          favourableness.com          circusperformers.org          find1.net          snmasteridx.com          freejobsearchinfo.com          pixelpipe.com }

puts Benchmark.measure {
  arr.each{|d| PublicSuffixService.parse(d) }
}
</pre>


Btw.. all tests are still passing at least in my machine ;)
