### PR TITLE
Updating .br tlds, according with Registro.br

### DIFF
--- a/lib/public_suffix_service/definitions.dat
+++ b/lib/public_suffix_service/definitions.dat
@@ -443,6 +443,7 @@ am.br
 arq.br
 art.br
 ato.br
+b.br
 bio.br
 blog.br
 bmd.br
@@ -454,6 +455,7 @@ com.br
 coop.br
 ecn.br
 edu.br
+emp.br
 eng.br
 esp.br
 etc.br
@@ -488,9 +490,12 @@ pro.br
 psc.br
 psi.br
 qsl.br
+radio.br
 rec.br
 slg.br
 srv.br
+taxi.br
+teo.br
 tmp.br
 trd.br
 tur.br


### PR DESCRIPTION
The brazilian tlds are a little outdated and Registro.br - responsible for brazilian tlds - have already opened a bug for public domain registry (https://bugzilla.mozilla.org/show_bug.cgi?id=638195). I decided to update now because I need these tlds. These tlds are already in use in Brazil so if you want to merge them it would be nice. 

Thanks
