### PR TITLE
Default rule list parsing from .dat file encoding causes ArgumentError on 1.9.2 

### DIFF
--- a/lib/public_suffix_service/rule_list.rb
+++ b/lib/public_suffix_service/rule_list.rb
@@ -247,7 +247,7 @@ module PublicSuffixService
       #
       # @return [File]
       def default_definition
-        File.new(File.join(File.dirname(__FILE__), "definitions.dat"))
+        File.new(File.join(File.dirname(__FILE__), "definitions.dat"), "r:utf-8")
       end
 
 


### PR DESCRIPTION
The default data file for rules gets loaded with an ASCII-US encoding, that breaks the regular expressions engine on RuleList#parse when trying to remove comments line =~ %r{^//}.

I'm forcing the file to be loaded as utf8 (should not be an issue if it  is really ASCII).
