### PR TITLE
Fixed mistake for .subdomain() in example code. 

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ Example domain with subdomains.
     domain.domain
     # => "google.com"
     domain.subdomain
-    # => "google.com"
+    # => "www.google.com"
 
 Simple validation example.
 


### PR DESCRIPTION
PublicSuffix.parse("www.google.com").subdomain returns "www.google.com"
