### PR TITLE
Added trd? method

### DIFF
--- a/lib/public_suffix/domain.rb
+++ b/lib/public_suffix/domain.rb
@@ -113,6 +113,12 @@ module PublicSuffix
       @trd
     end
 
+    # Returns a boolean value to verify if trd exist or not
+    #
+    # @return [Boolean, nil]
+    def trd?
+      !@trd.nil?
+    end
 
     # Returns the full domain name.
     #


### PR DESCRIPTION
Hi, i just thought, using this gem that i need this method to verify if given a domain exist or not the subdomain.

Example:

``` ruby

>> require 'public_suffix'
=> true
>> a = PublicSuffix::parse("www.google.it")
=> #<PublicSuffix::Domain:0x101a7a790 @trd="www", @sld="google", @tld="it">
>> a.trd
=> "www"
>> a.trd?
=> true
>> b = PublicSuffix::parse("google.it")
=> #<PublicSuffix::Domain:0x101a59a40 @trd=nil, @sld="google", @tld="it">
>> b.trd
=> nil
>> b.trd?
=> false

```
