### PR TITLE
New brazilian TLD

### DIFF
--- a/lib/public_suffix/definitions.txt
+++ b/lib/public_suffix/definitions.txt
@@ -422,6 +422,7 @@ cnt.br
 com.br
 coop.br
 ecn.br
+eco.br
 edu.br
 emp.br
 eng.br


### PR DESCRIPTION
Hi,

The brazilian registry was announced a new TLD called eco.br, available since July 5. See http://registro.br/anuncios/20120627.html for further details. I included a new entry for eco.br in lib/public_suffix/definitions.txt.

Thank you.
