### PR TITLE
Allow a custom List on `PublicSuffix.parse`

### DIFF
--- a/lib/public_suffix.rb
+++ b/lib/public_suffix.rb
@@ -24,10 +24,10 @@ module PublicSuffix
   # Parses +domain+ and returns the
   # {PublicSuffix::Domain} instance.
   #
-  # Parsing uses the default {PublicSuffix::List}.
-  #
   # @param  [String, #to_s] domain
   #   The domain name or fully qualified domain name to parse.
+  # @param  [PublicSuffix::List] list
+  #   The rule list to search, defaults to the default {PublicSuffix::List}
   #
   # @return [PublicSuffix::Domain]
   #
@@ -61,8 +61,8 @@ module PublicSuffix
   #   If a rule for +domain+ is found, but the rule
   #   doesn't allow +domain+.
   #
-  def self.parse(domain)
-    rule = List.default.find(domain)
+  def self.parse(domain, list = List.default)
+    rule = list.find(domain)
 
     if rule.nil?
       raise DomainInvalid, "`#{domain}' is not a valid domain"

--- a/test/unit/public_suffix_test.rb
+++ b/test/unit/public_suffix_test.rb
@@ -52,6 +52,16 @@ class PublicSuffixTest < Test::Unit::TestCase
     assert_equal "www",     domain.trd
   end
 
+  def test_self_parse_a_domain_with_custom_list
+    list = PublicSuffix::List.new
+    list << PublicSuffix::Rule.factory("test")
+
+    domain = PublicSuffix.parse("www.example.test", list)
+    assert_equal "test",    domain.tld
+    assert_equal "example", domain.sld
+    assert_equal "www",     domain.trd
+  end
+
   def test_self_parse_raises_with_invalid_domain
     error = assert_raise(PublicSuffix::DomainInvalid) { PublicSuffix.parse("example.zip") }
     assert_match %r{example\.zip}, error.message


### PR DESCRIPTION
I needed a way to allow ".test" as a valid TLD when using `PublicSufffix.parse`. Currently, the only way to do that is to add a custom rule to the default list.

This patch allows one to pass in a custom list when using `PublicSuffix.parse`. This way the default list can remain unchanged; eg:

``` ruby
list = PublicSuffix::List.new
list << PublicSuffix::Rule.factory("test")

PublicSuffix.parse("example.test", list)
#=> example.test
```
