### PR TITLE
Don't unnecessarily reload definitions.txt when dis/enabling private domains

### DIFF
--- a/lib/public_suffix/list.rb
+++ b/lib/public_suffix/list.rb
@@ -80,8 +80,11 @@ module PublicSuffix
     #
     # @return [PublicSuffix::List]
     def self.private_domains=(value)
-      @private_domains = !!value
-      self.clear
+      if @private_domains != !!value
+        @private_domains = !!value
+        self.clear
+      end
+      self
     end
 
     # Sets the default rule list to +nil+.


### PR DESCRIPTION
We called .clear even if support was disabled and we set it to disabled again