### PR TITLE
fix bug where domain with \.{2,} in it is considered valid

### DIFF
--- a/lib/public_suffix.rb
+++ b/lib/public_suffix.rb
@@ -34,15 +34,15 @@ module PublicSuffix
   # @example Parse a valid domain
   #   PublicSuffix.parse("google.com")
   #   # => #<PublicSuffix::Domain ...>
-  # 
+  #
   # @example Parse a valid subdomain
   #   PublicSuffix.parse("www.google.com")
   #   # => #<PublicSuffix::Domain ...>
-  # 
+  #
   # @example Parse a fully qualified domain
   #   PublicSuffix.parse("google.com.")
   #   # => #<PublicSuffix::Domain ...>
-  # 
+  #
   # @example Parse a fully qualified domain (subdomain)
   #   PublicSuffix.parse("www.google.com.")
   #   # => #<PublicSuffix::Domain ...>
@@ -64,7 +64,7 @@ module PublicSuffix
   def self.parse(domain, list = List.default)
     rule = list.find(domain)
 
-    if rule.nil?
+    if rule.nil? || domain.include?('..')
       raise DomainInvalid, "`#{domain}' is not a valid domain"
     end
     if !rule.allow?(domain)
@@ -112,7 +112,7 @@ module PublicSuffix
   #   # => false
   #   PublicSuffix.valid?("www.example.do")
   #   # => true
-  # 
+  #
   # @example Validate a fully qualified domain
   #   PublicSuffix.valid?("google.com.")
   #   # => true

--- a/lib/public_suffix/domain.rb
+++ b/lib/public_suffix/domain.rb
@@ -75,6 +75,9 @@ module PublicSuffix
       name
     end
 
+    # Makes Domain act like a string
+    alias :to_str :to_s
+
     # Returns an array containing the domain parts.
     #
     # @return [Array<String, nil>]

--- a/lib/public_suffix/rule.rb
+++ b/lib/public_suffix/rule.rb
@@ -57,7 +57,7 @@ module PublicSuffix
     #
     # This represent the base class for a Rule definition
     # in the {Public Suffix List}[http://publicsuffix.org].
-    # 
+    #
     # This is intended to be an Abstract class
     # and you shouldn't create a direct instance. The only purpose
     # of this class is to expose a common interface
@@ -113,10 +113,10 @@ module PublicSuffix
     # You can use the <tt>#match?</tt> method.
     #
     #   rule = PublicSuffix::Rule.factory("com")
-    #   
+    #
     #   rule.match?("google.com")
     #   # => true
-    #   
+    #
     #   rule.match?("google.com")
     #   # => false
     #
@@ -125,12 +125,12 @@ module PublicSuffix
     # to learn more about rule priority.
     #
     # When you have the right rule, you can use it to tokenize the domain name.
-    # 
+    #
     #   rule = PublicSuffix::Rule.factory("com")
-    # 
+    #
     #   rule.decompose("google.com")
     #   # => ["google", "com"]
-    # 
+    #
     #   rule.decompose("www.google.com")
     #   # => ["www.google", "com"]
     #
@@ -208,7 +208,7 @@ module PublicSuffix
       #   # => true
       #
       def allow?(domain)
-        !decompose(domain).last.nil?
+        !domain.include?('..') && !decompose(domain).last.nil?
       end
 
 
@@ -346,7 +346,7 @@ module PublicSuffix
       #
       # See http://publicsuffix.org/format/:
       # If the prevailing rule is a exception rule,
-      # modify it by removing the leftmost label. 
+      # modify it by removing the leftmost label.
       #
       # @return [Array<String>]
       def parts

--- a/test/acceptance_test.rb
+++ b/test/acceptance_test.rb
@@ -27,6 +27,8 @@ class AcceptanceTest < Test::Unit::TestCase
   InvalidCases = [
     ["nic.ke",                  PublicSuffix::DomainNotAllowed],
     ["http://www.google.com",   PublicSuffix::DomainInvalid],
+    ['a..com',                  PublicSuffix::DomainInvalid],
+    ['a..b.com',                PublicSuffix::DomainInvalid],
     [nil,                       PublicSuffix::DomainInvalid],
     ["",                        PublicSuffix::DomainInvalid],
     ["  ",                      PublicSuffix::DomainInvalid],


### PR DESCRIPTION
see: https://github.com/weppos/publicsuffix-ruby/issues/25
