### PR TITLE
Fixes all tests by using "qqq" rather than "zip" as an invalid suffix

### DIFF
--- a/lib/public_suffix.rb
+++ b/lib/public_suffix.rb
@@ -34,15 +34,15 @@ module PublicSuffix
   # @example Parse a valid domain
   #   PublicSuffix.parse("google.com")
   #   # => #<PublicSuffix::Domain ...>
-  # 
+  #
   # @example Parse a valid subdomain
   #   PublicSuffix.parse("www.google.com")
   #   # => #<PublicSuffix::Domain ...>
-  # 
+  #
   # @example Parse a fully qualified domain
   #   PublicSuffix.parse("google.com.")
   #   # => #<PublicSuffix::Domain ...>
-  # 
+  #
   # @example Parse a fully qualified domain (subdomain)
   #   PublicSuffix.parse("www.google.com.")
   #   # => #<PublicSuffix::Domain ...>
@@ -104,7 +104,7 @@ module PublicSuffix
   #   # => true
   #
   # @example Validate a not-assigned domain
-  #   PublicSuffix.valid?("example.zip")
+  #   PublicSuffix.valid?("example.qqq")
   #   # => false
   #
   # @example Validate a not-allowed domain
@@ -112,7 +112,7 @@ module PublicSuffix
   #   # => false
   #   PublicSuffix.valid?("www.example.do")
   #   # => true
-  # 
+  #
   # @example Validate a fully qualified domain
   #   PublicSuffix.valid?("google.com.")
   #   # => true

--- a/lib/public_suffix/domain.rb
+++ b/lib/public_suffix/domain.rb
@@ -146,8 +146,8 @@ module PublicSuffix
     # as a valid domain name and simply applies the necessary transformations.
     #
     #   # This is an invalid domain
-    #   PublicSuffix::Domain.new("zip", "google").domain
-    #   # => "google.zip"
+    #   PublicSuffix::Domain.new("qqq", "google").domain
+    #   # => "google.qqq"
     #
     # This method returns a FQD, not just the domain part.
     # To get the domain part, use <tt>#sld</tt> (aka second level domain).
@@ -184,8 +184,8 @@ module PublicSuffix
     # as a valid domain name and simply applies the necessary transformations.
     #
     #   # This is an invalid domain
-    #   PublicSuffix::Domain.new("zip", "google", "www").subdomain
-    #   # => "www.google.zip"
+    #   PublicSuffix::Domain.new("qqq", "google", "www").subdomain
+    #   # => "www.google.qqq"
     #
     # This method returns a FQD, not just the domain part.
     # To get the subdomain part, use <tt>#trd</tt> (aka third level domain).
@@ -240,7 +240,7 @@ module PublicSuffix
     #
     #   # This is an invalid domain, but returns true
     #   # because this method doesn't validate the content.
-    #   PublicSuffix::Domain.new("zip", "google").domain?
+    #   PublicSuffix::Domain.new("qqq", "google").domain?
     #   # => true
     #
     # @see #subdomain?
@@ -272,7 +272,7 @@ module PublicSuffix
     #
     #   # This is an invalid domain, but returns true
     #   # because this method doesn't validate the content.
-    #   PublicSuffix::Domain.new("zip", "google", "www").subdomain?
+    #   PublicSuffix::Domain.new("qqq", "google", "www").subdomain?
     #   # => true
     #
     # @see #domain?
@@ -313,7 +313,7 @@ module PublicSuffix
     #   # => true
     #
     # @example Check a not-assigned domain
-    #   Domain.new("zip", "example").valid?
+    #   Domain.new("qqq", "example").valid?
     #   # => false
     #
     # @example Check a not-allowed domain
@@ -345,7 +345,7 @@ module PublicSuffix
     #   # => true
     #
     #   # This is an invalid domain
-    #   PublicSuffix::Domain.new("zip", "google").false?
+    #   PublicSuffix::Domain.new("qqq", "google").false?
     #   # => true
     #
     # @see #domain?
@@ -372,7 +372,7 @@ module PublicSuffix
     #   # => true
     #
     #   # This is an invalid domain
-    #   PublicSuffix::Domain.new("zip", "google", "www").subdomain?
+    #   PublicSuffix::Domain.new("qqq", "google", "www").subdomain?
     #   # => false
     #
     # @see #subdomain?

--- a/test/unit/domain_test.rb
+++ b/test/unit/domain_test.rb
@@ -85,24 +85,24 @@ class PublicSuffix::DomainTest < Test::Unit::TestCase
 
   def test_domain
     assert_equal nil, @klass.new("com").domain
-    assert_equal nil, @klass.new("zip").domain
+    assert_equal nil, @klass.new("qqq").domain
     assert_equal "google.com", @klass.new("com", "google").domain
-    assert_equal "google.zip", @klass.new("zip", "google").domain
+    assert_equal "google.qqq", @klass.new("qqq", "google").domain
     assert_equal "google.com", @klass.new("com", "google", "www").domain
-    assert_equal "google.zip", @klass.new("zip", "google", "www").domain
+    assert_equal "google.qqq", @klass.new("qqq", "google", "www").domain
   end
 
   def test_subdomain
     assert_equal nil, @klass.new("com").subdomain
-    assert_equal nil, @klass.new("zip").subdomain
+    assert_equal nil, @klass.new("qqq").subdomain
     assert_equal nil, @klass.new("com", "google").subdomain
-    assert_equal nil, @klass.new("zip", "google").subdomain
+    assert_equal nil, @klass.new("qqq", "google").subdomain
     assert_equal "www.google.com", @klass.new("com", "google", "www").subdomain
-    assert_equal "www.google.zip", @klass.new("zip", "google", "www").subdomain
+    assert_equal "www.google.qqq", @klass.new("qqq", "google", "www").subdomain
   end
 
   def test_rule
-    assert_equal nil,                                      @klass.new("zip").rule
+    assert_equal nil, @klass.new("qqq").rule
     assert_equal PublicSuffix::Rule.factory("com"), @klass.new("com").rule
     assert_equal PublicSuffix::Rule.factory("com"), @klass.new("com", "google").rule
     assert_equal PublicSuffix::Rule.factory("com"), @klass.new("com", "google", "www").rule
@@ -111,28 +111,28 @@ class PublicSuffix::DomainTest < Test::Unit::TestCase
 
   def test_domain_question
     assert  @klass.new("com", "google").domain?
-    assert  @klass.new("zip", "google").domain?
+    assert  @klass.new("qqq", "google").domain?
     assert  @klass.new("com", "google", "www").domain?
     assert !@klass.new("com").domain?
   end
 
   def test_subdomain_question
     assert  @klass.new("com", "google", "www").subdomain?
-    assert  @klass.new("zip", "google", "www").subdomain?
+    assert  @klass.new("qqq", "google", "www").subdomain?
     assert !@klass.new("com").subdomain?
     assert !@klass.new("com", "google").subdomain?
   end
 
   def test_is_a_domain_question
     assert  @klass.new("com", "google").is_a_domain?
-    assert  @klass.new("zip", "google").is_a_domain?
+    assert  @klass.new("qqq", "google").is_a_domain?
     assert !@klass.new("com", "google", "www").is_a_domain?
     assert !@klass.new("com").is_a_domain?
   end
 
   def test_is_a_subdomain_question
     assert  @klass.new("com", "google", "www").is_a_subdomain?
-    assert  @klass.new("zip", "google", "www").is_a_subdomain?
+    assert  @klass.new("qqq", "google", "www").is_a_subdomain?
     assert !@klass.new("com").is_a_subdomain?
     assert !@klass.new("com", "google").is_a_subdomain?
   end
@@ -143,9 +143,9 @@ class PublicSuffix::DomainTest < Test::Unit::TestCase
     assert  @klass.new("com", "example", "www").valid?
 
     # not-assigned
-    assert !@klass.new("zip").valid?
-    assert !@klass.new("zip", "example").valid?
-    assert !@klass.new("zip", "example", "www").valid?
+    assert !@klass.new("qqq").valid?
+    assert !@klass.new("qqq", "example").valid?
+    assert !@klass.new("qqq", "example", "www").valid?
 
     # not-allowed
     assert !@klass.new("ke").valid?
@@ -155,14 +155,14 @@ class PublicSuffix::DomainTest < Test::Unit::TestCase
 
   def test_valid_domain_question
     assert  @klass.new("com", "google").valid_domain?
-    assert !@klass.new("zip", "google").valid_domain?
+    assert !@klass.new("qqq", "google").valid_domain?
     assert  @klass.new("com", "google", "www").valid_domain?
     assert !@klass.new("com").valid_domain?
   end
 
   def test_valid_subdomain_question
     assert  @klass.new("com", "google", "www").valid_subdomain?
-    assert !@klass.new("zip", "google", "www").valid_subdomain?
+    assert !@klass.new("qqq", "google", "www").valid_subdomain?
     assert !@klass.new("com").valid_subdomain?
     assert !@klass.new("com", "google").valid_subdomain?
   end

--- a/test/unit/public_suffix_test.rb
+++ b/test/unit/public_suffix_test.rb
@@ -51,12 +51,12 @@ class PublicSuffixTest < Test::Unit::TestCase
     assert_equal "example", domain.sld
     assert_equal "www",     domain.trd
   end
-  
+
   def test_private_domains_are_enabled_by_default
     domain = PublicSuffix.parse("www.example.blogspot.com")
     assert_equal "blogspot.com",    domain.tld
   end
-  
+
   def test_disable_support_for_private_domains
     begin
       PublicSuffix::List.private_domains = false
@@ -78,8 +78,8 @@ class PublicSuffixTest < Test::Unit::TestCase
   end
 
   def test_self_parse_raises_with_invalid_domain
-    error = assert_raise(PublicSuffix::DomainInvalid) { PublicSuffix.parse("example.zip") }
-    assert_match %r{example\.zip}, error.message
+    error = assert_raise(PublicSuffix::DomainInvalid) { PublicSuffix.parse("example.qqq") }
+    assert_match %r{example\.qqq}, error.message
   end
 
   def test_self_parse_raises_with_unallowed_domain
@@ -102,14 +102,14 @@ class PublicSuffixTest < Test::Unit::TestCase
 
   # Returns false when domain has an invalid TLD
   def test_self_valid_with_invalid_tld
-    assert !PublicSuffix.valid?("google.zip")
-    assert !PublicSuffix.valid?("www.google.zip")
+    assert !PublicSuffix.valid?("google.qqq")
+    assert !PublicSuffix.valid?("www.google.qqq")
   end
 
   def test_self_valid_with_fully_qualified_domain_name
     assert  PublicSuffix.valid?("google.com.")
     assert  PublicSuffix.valid?("google.co.uk.")
-    assert !PublicSuffix.valid?("google.zip.")
+    assert !PublicSuffix.valid?("google.qqq.")
   end
 
 end


### PR DESCRIPTION
The "zip" suffix was added to the list without the tests being updated. This fixes that by using "qqq" rather than "zip". All tests pass locally when using:

```
bundle exec rake
```

I noticed the failures when putting together https://github.com/weppos/publicsuffix-ruby/pull/49 so it might be best to merge this PR first. 
