### PR TITLE
Domain validation use cases

### DIFF
--- a/test/unit/list_test.rb
+++ b/test/unit/list_test.rb
@@ -89,11 +89,6 @@ class PublicSuffix::ListTest < Minitest::Unit::TestCase
     assert_equal 2, list.select("british-library.uk").size
   end
 
-  def test_select_returns_empty_when_domain_has_scheme
-    assert_equal [], list.select("http://google.com")
-    assert_not_equal [], list.select("google.com")
-  end
-
   def test_select_returns_empty_when_domain_is_nil
     assert_equal [], list.select(nil)
   end
@@ -101,6 +96,11 @@ class PublicSuffix::ListTest < Minitest::Unit::TestCase
   def test_select_returns_empty_when_domain_is_blank
     assert_equal [], list.select("")
     assert_equal [], list.select("  ")
+  end
+
+  def test_select_returns_empty_when_domain_has_scheme
+    assert_equal [], list.select("http://google.com")
+    assert_not_equal [], list.select("google.com")
   end
 
 


### PR DESCRIPTION
This is a list of cases where PublicSuffix.valid? returns true and the
domain is apparently invalid.
- Domain has a scheme :// (GH-15, GH-33)
- Domain contains spaces (GH-52)
- Domain contains double (GH-25, GH-36)

This is an hard decision to make, but as I explained more than one, the
purpose of this library is not to formally validate the syntax of a
domain or an URI.

The library expects the input to be a domain, and can't run all the
possible guesses and checks to guarantee the input. This is a
constraint that the caller must ensure. Entering the business of
validating URIs would make the maintenance of this library very
complicated.

This is an example of a simple validation that could be used before
submitting the string for tokenisation.

``` ruby
def valid_uri?(name)
  uri = URI.parse(name)
  uri.host != nil
rescue
  false
end
```

I don't exclude to add such filter in the future in the `#valid?`
method, may be as wrapper for the current `valid?` behaviour. But for
the time being, this library is not intended to formally validate URIs
or domains.

(closes GH-25, closes GH-36, closes GH-52)
