### PR TITLE
Use Enumerable#detect instead of select+first combo.

### DIFF
--- a/lib/public_suffix/list.rb
+++ b/lib/public_suffix/list.rb
@@ -276,7 +276,7 @@ module PublicSuffix
     # @return [PublicSuffix::Rule::*, nil]
     def find(domain)
       rules = select(domain)
-      rules.select { |r|   r.type == :exception }.first ||
+      rules.detect { |r|   r.type == :exception } ||
       rules.inject { |t,r| t.length > r.length ? t : r }
     end
 


### PR DESCRIPTION
Use Enumerable#detect ( http://ruby-doc.org/core-2.1.5/Enumerable.html#method-i-detect ) instead of select+first combo. 
It's faster since it stop iterating on first match.
