### PR TITLE
Ignore case for parsing and validating

### DIFF
--- a/lib/public_suffix.rb
+++ b/lib/public_suffix.rb
@@ -55,7 +55,8 @@ module PublicSuffix
   #   doesn't allow +domain+.
   #
   def self.parse(domain, list = List.default)
-    rule = list.find(domain)
+    domain = domain.to_s.downcase
+    rule   = list.find(domain)
 
     if rule.nil?
       raise DomainInvalid, "`#{domain}' is not a valid domain"
@@ -117,7 +118,8 @@ module PublicSuffix
   #   # => false
   #
   def self.valid?(domain)
-    rule = List.default.find(domain)
+    domain = domain.to_s.downcase
+    rule   = List.default.find(domain)
     !rule.nil? && rule.allow?(domain)
   end
 

--- a/test/acceptance_test.rb
+++ b/test/acceptance_test.rb
@@ -60,6 +60,24 @@ class AcceptanceTest < Test::Unit::TestCase
     end
   end
 
+  
+  CaseCases = [
+      ["Www.google.com",          ["www", "google", "com"]],
+      ["www.Google.com",          ["www", "google", "com"]],
+      ["www.google.Com",          ["www", "google", "com"]],
+  ]
+
+  def test_ignore_case
+    CaseCases.each do |name, results|
+      domain = PublicSuffix.parse(name)
+      trd, sld, tld = results
+      assert_equal tld, domain.tld, "Invalid tld for `#{name}'"
+      assert_equal sld, domain.sld, "Invalid sld for `#{name}'"
+      assert_equal trd, domain.trd, "Invalid trd for `#{name}'"
+      assert PublicSuffix.valid?(name)
+    end
+  end
+
 
   def valid_uri?(name)
     uri = URI.parse(name)


### PR DESCRIPTION
This commit fixes GH-62. The caveat, is that in case of #parse the
returned domain will contain lower-case tokens.

I tried to keep the case unchanged by patching List#select, but it
turned out I had to patch several methods inside Rule subclasses as well.