### PR TITLE
Initializes instance vars to avoid verbose warnings

### DIFF
--- a/lib/public_suffix/list.rb
+++ b/lib/public_suffix/list.rb
@@ -69,6 +69,7 @@ module PublicSuffix
     #
     # @return [Boolean]
     def self.private_domains?
+      @private_domains = nil unless defined? @private_domains
       @private_domains != false
     end
 
@@ -109,6 +110,7 @@ module PublicSuffix
     #
     # @return [File]
     def self.default_definition
+      @default_definition = nil unless defined? @default_definition
       @default_definition || File.new(DEFAULT_DEFINITION_PATH, "r:utf-8")
     end
 

--- a/test/unit/list_test.rb
+++ b/test/unit/list_test.rb
@@ -54,6 +54,22 @@ class PublicSuffix::ListTest < Test::Unit::TestCase
     assert_equal PublicSuffix::Rule.factory("net"), @list.find("google.net")
   end
 
+  def test_init_private_domains
+    PublicSuffix::List.remove_instance_variable :@private_domains if PublicSuffix::List.instance_variables.include? :@private_domains
+    refute PublicSuffix::List.instance_variables.include? :@private_domains
+
+    PublicSuffix::List.private_domains?
+    assert PublicSuffix::List.instance_variables.include? :@private_domains
+  end
+
+  def test_init_default_definition
+    PublicSuffix::List.remove_instance_variable :@default_definition if PublicSuffix::List.instance_variables.include? :@default_definition
+    refute PublicSuffix::List.instance_variables.include? :@default_definition
+
+    PublicSuffix::List.default_definition
+    assert PublicSuffix::List.instance_variables.include? :@default_definition
+  end
+
   def test_empty?
     assert  @list.empty?
     @list.add(PublicSuffix::Rule.factory(""))


### PR DESCRIPTION
`PublicSuffix::List` is extremely verbose when Ruby warnings are enabled, making it difficult to test applications making use of it when warnings are on.

Chiefly,  this is due to the instance var `@private_domains` being uninitialized, as well as `@default_definition`. These result in many hundreds of warnings similar to 

```
publicsuffix-ruby/lib/public_suffix/list.rb:72: warning: instance variable @private_domains not initialized
publicsuffix-ruby/lib/public_suffix/list.rb:72: warning: instance variable @private_domains not initialized
publicsuffix-ruby/lib/public_suffix/list.rb:112: warning: instance variable @default_definition not initialized

```

This patch initializes those as `nil` immediately before they're read to avoid warnings, and supplies unit tests to verify the uninitialized state before calling the class methods utilizing them, and initialized state after calling them. 