### PR TITLE
Respect RFC 1035 label limits for parsed domains

### DIFF
--- a/lib/public_suffix/list.rb
+++ b/lib/public_suffix/list.rb
@@ -292,8 +292,11 @@ module PublicSuffix
       return [] if domain.to_s =~ /\A\s*\z/
       # raise DomainInvalid, "`#{domain}' is not expected to contain a scheme"
       return [] if domain.include?("://")
+      labels = Domain.domain_to_labels(domain)
+      # raise DomainInvalid, "`#{domain}' contains a label exceeding 63 characters"
+      return [] if labels.select { |l| l.size > 63 }.any?
 
-      indices = (@indexes[Domain.domain_to_labels(domain).first] || [])
+      indices = (@indexes[labels.first] || [])
       @rules.values_at(*indices).select { |rule| rule.match?(domain) }
     end
 

--- a/test/unit/list_test.rb
+++ b/test/unit/list_test.rb
@@ -103,6 +103,10 @@ class PublicSuffix::ListTest < Test::Unit::TestCase
     assert_not_equal [], list.select("google.com")
   end
 
+  def test_select_returns_empty_when_domain_has_overlong_label
+    assert_equal [], list.select("foo.abcdefghijabcdefghijabcdefghijabcdefghijabcdefghijabcdefghijabcde.com")
+    assert_equal [], list.select("abcdefghijabcdefghijabcdefghijabcdefghijabcdefghijabcdefghijabcde.co.uk")
+  end
 
   def test_self_default_getter
     assert_equal     nil, PublicSuffix::List.class_eval { @default }


### PR DESCRIPTION
If a label in a domain exceeds 63 characters, raise a parse error in accord with RFC 1035 rather than returning an invalid domain.