### PR TITLE
Don't duplicate rule indices when creating index.

### DIFF
--- a/lib/public_suffix/list.rb
+++ b/lib/public_suffix/list.rb
@@ -156,7 +156,6 @@ module PublicSuffix
     #
     def initialize(&block)
       @rules   = []
-      @indexes = {}
       yield(self) if block_given?
       create_index!
     end
@@ -169,6 +168,7 @@ module PublicSuffix
     # where Rule#labels.first is 'us' @indexes['us'] #=> [5,4], that way in 
     # select we can avoid mapping every single rule against the candidate domain.
     def create_index!
+      @indexes = {}
       @rules.map { |l| l.labels.first }.each_with_index do |elm, inx|
         if !@indexes.has_key?(elm)
           @indexes[elm] = [inx]

--- a/test/unit/list_test.rb
+++ b/test/unit/list_test.rb
@@ -54,6 +54,13 @@ class PublicSuffix::ListTest < Minitest::Unit::TestCase
     assert_equal PublicSuffix::Rule.factory("net"), @list.find("google.net")
   end
 
+  def test_add_should_not_duplicate_indices
+    @list = PublicSuffix::List.parse("com")
+    @list.add(PublicSuffix::Rule.factory("net"))
+
+    assert_equal @list.indexes["com"], [0]
+  end
+
   def test_empty?
     assert  @list.empty?
     @list.add(PublicSuffix::Rule.factory(""))


### PR DESCRIPTION
By default, the rule index is re-created when new rules are added to a list.

The index isn't cleared when this happens, so the index allows repeated addition of the same indices for the same rule. This in turn slows down `List.find`.

We (Flippa) add 39 new rules to the default list, which means for a TLD like '.it', 15,129 rules are checked instead of the 369 unique ones.