### PR TITLE
Performance optimization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 
 - NEW: Added PublicSuffix.domain # => sld.tld
 
+- CHANGED: Considerable performance improvements (GH-92)
+
 - CHANGED: Updated definitions.
 
 - CHANGED: PublicSuffix::List.default_definition no longer memoizes the data (no need to keep it in memory as the list is already memoized) Also the method now returns a String, instead of a File pointer (that was never closed).

--- a/Gemfile
+++ b/Gemfile
@@ -5,3 +5,4 @@ gemspec
 gem 'minitest'
 gem 'minitest-reporters'
 gem 'coveralls', require: false
+gem 'memory_profiler', require: false

--- a/Gemfile
+++ b/Gemfile
@@ -5,4 +5,7 @@ gemspec
 gem 'minitest'
 gem 'minitest-reporters'
 gem 'coveralls', require: false
-gem 'memory_profiler', require: false
+
+if !RUBY_VERSION.start_with?("2.0")
+  gem 'memory_profiler', require: false
+end

--- a/Rakefile
+++ b/Rakefile
@@ -58,12 +58,11 @@ task package: [:gemspec]
 require 'rake/testtask'
 
 Rake::TestTask.new do |t|
-  t.libs << "test"
+  t.libs = %w( lib test )
   t.pattern = "test/**/*_test.rb"
   t.verbose = !!ENV["VERBOSE"]
   t.warning = !!ENV["WARNING"]
 end
-
 
 require 'yard'
 require 'yard/rake/yardoc_task'

--- a/lib/public_suffix.rb
+++ b/lib/public_suffix.rb
@@ -14,6 +14,11 @@ require 'public_suffix/list'
 
 module PublicSuffix
 
+  DOT   = ".".freeze
+  BANG  = "!".freeze
+  STAR  = "*".freeze
+
+
   # Parses +name+ and returns the {PublicSuffix::Domain} instance.
   #
   # @example Parse a valid domain
@@ -132,13 +137,13 @@ module PublicSuffix
   def self.decompose(name, rule)
     left, right = rule.decompose(name)
 
-    parts = left.split(".")
+    parts = left.split(DOT)
     # If we have 0 parts left, there is just a tld and no domain or subdomain
     # If we have 1 part  left, there is just a tld, domain and not subdomain
     # If we have 2 parts left, the last part is the domain, the other parts (combined) are the subdomain
     tld = right
     sld = parts.empty? ? nil : parts.pop
-    trd = parts.empty? ? nil : parts.join(".")
+    trd = parts.empty? ? nil : parts.join(DOT)
 
     Domain.new(tld, sld, trd)
   end
@@ -147,11 +152,11 @@ module PublicSuffix
   def self.normalize(name)
     name = name.to_s.dup
     name.strip!
-    name.chomp!(".")
+    name.chomp!(DOT)
     name.downcase!
 
     return DomainInvalid.new("Name is blank") if name.empty?
-    return DomainInvalid.new("Name starts with a dot") if name.start_with?(".")
+    return DomainInvalid.new("Name starts with a dot") if name.start_with?(DOT)
     return DomainInvalid.new("%s is not expected to contain a scheme" % name) if name.include?("://")
     name
   end

--- a/lib/public_suffix/domain.rb
+++ b/lib/public_suffix/domain.rb
@@ -29,7 +29,7 @@ module PublicSuffix
     #   # => ['uk', 'co', 'google']
     #
     def self.domain_to_labels(domain)
-      domain.to_s.split(".").reverse
+      domain.to_s.split(DOT).reverse
     end
 
     attr_reader :tld, :sld, :trd
@@ -105,7 +105,7 @@ module PublicSuffix
     #   # => "www.google.com"
     #
     def name
-      [@trd, @sld, @tld].compact.join(".")
+      [@trd, @sld, @tld].compact.join(DOT)
     end
 
     # Returns a domain-like representation of this object
@@ -138,7 +138,7 @@ module PublicSuffix
     # @return [String]
     def domain
       if domain?
-        [@sld, @tld].join(".")
+        [@sld, @tld].join(DOT)
       end
     end
 
@@ -172,7 +172,7 @@ module PublicSuffix
     # @return [String]
     def subdomain
       if subdomain?
-        [@trd, @sld, @tld].join(".")
+        [@trd, @sld, @tld].join(DOT)
       end
     end
 

--- a/lib/public_suffix/domain.rb
+++ b/lib/public_suffix/domain.rb
@@ -10,27 +10,42 @@ module PublicSuffix
 
   class Domain
 
-    # Splits a string into its possible labels
-    # as a domain in reverse order from the input string.
+    # Splits a string into the dot-separated parts and reverse them.
     #
-    # The input is not validated, but it is assumed to be a valid domain.
-    #
-    # @param  [String, #to_s] domain
-    #   The domain name to split.
-    #
-    # @return [Array<String>]
+    # The input is not validated, but it is assumed to be a valid domain name.
     #
     # @example
     #
-    #   domain_to_labels('google.com')
-    #   # => ['com', 'google']
+    #   name_to_labels('example.com')
+    #   # => ['com', 'example']
     #
-    #   domain_to_labels('google.co.uk')
-    #   # => ['uk', 'co', 'google']
+    #   name_to_labels('example.co.uk')
+    #   # => ['uk', 'co', 'example']
     #
-    def self.domain_to_labels(domain)
-      domain.to_s.split(DOT).reverse
+    # @param  name [String, #to_s] The domain name to split.
+    # @return [Array<String>]
+    def self.name_to_labels(name)
+      name_to_parts(name).reverse
     end
+
+    # Splits a string into the dot-separated parts.
+    #
+    # The input is not validated, but it is assumed to be a valid domain name.
+    #
+    # @example
+    #
+    #   name_to_parts('example.com')
+    #   # => ['example', 'com']
+    #
+    #   name_to_parts('example.co.uk')
+    #   # => ['example', 'co', 'uk']
+    #
+    # @param  name [String, #to_s] The domain name to split.
+    # @return [Array<String>]
+    def self.name_to_parts(name)
+      name.to_s.split(DOT)
+    end
+
 
     attr_reader :tld, :sld, :trd
 

--- a/lib/public_suffix/list.rb
+++ b/lib/public_suffix/list.rb
@@ -239,7 +239,7 @@ module PublicSuffix
     # - An exclamation mark (!) at the start of a rule marks an exception to a previous wildcard rule.
     #   An exception rule takes priority over any other matching rule.
     #
-    # == Algorithm description
+    # ## Algorithm description
     #
     # 1. Match domain against all rules and take note of the matching ones.
     # 2. If no rules match, the prevailing rule is "*".
@@ -250,14 +250,15 @@ module PublicSuffix
     #    which directly match the labels of the prevailing rule (joined by dots).
     # 7. The registered domain is the public suffix plus one additional label.
     #
-    # @param  [String, #to_s] name The domain name.
+    # @param  name [String, #to_s] The domain name.
     # @param  [PublicSuffix::Rule::*] default The default rule to return in case no rule matches.
     # @return [PublicSuffix::Rule::*]
     def find(name, default = default_rule)
-      rules = select(name)
-      rules.detect { |r| r.class == Rule::Exception }     ||
-      rules.inject { |t,r| t.length > r.length ? t : r }  ||
-      default
+      rule = select(name).inject do |l, r|
+        return r if r.class == Rule::Exception
+        l.length > r.length ? l : r
+      end
+      rule || default
     end
 
     # Selects all the rules matching given domain.

--- a/lib/public_suffix/list.rb
+++ b/lib/public_suffix/list.rb
@@ -42,6 +42,8 @@ module PublicSuffix
   class List
     include Enumerable
 
+    DEFAULT_DEFINITION_PATH = File.join(File.dirname(__FILE__), "..", "..", "data", "definitions.txt")
+
     # Gets the default rule list.
     #
     # Initializes a new {PublicSuffix::List} parsing the content
@@ -77,8 +79,6 @@ module PublicSuffix
     def self.reload
       self.clear.default
     end
-
-    DEFAULT_DEFINITION_PATH = File.join(File.dirname(__FILE__), "..", "..", "data", "definitions.txt")
 
     # Reads and returns the content of the the default definition list.
     #
@@ -255,7 +255,7 @@ module PublicSuffix
     # @return [PublicSuffix::Rule::*]
     def find(name, default = default_rule)
       rules = select(name)
-      rules.detect { |r|   r.type == :exception }         ||
+      rules.detect { |r| r.class == Rule::Exception }     ||
       rules.inject { |t,r| t.length > r.length ? t : r }  ||
       default
     end

--- a/lib/public_suffix/list.rb
+++ b/lib/public_suffix/list.rb
@@ -95,15 +95,18 @@ module PublicSuffix
     # @param  private_domain [Boolean] whether to ignore the private domains section.
     # @return [Array<PublicSuffix::Rule::*>]
     def self.parse(input, private_domains: true)
+      comment_token = "//".freeze
+      private_token = "===BEGIN PRIVATE DOMAINS===".freeze
+      
       new do |list|
         input.each_line do |line|
           line.strip!
-          break if !private_domains && line.include?('===BEGIN PRIVATE DOMAINS===')
+          break if !private_domains && line.include?(private_token)
           # strip blank lines
           if line.empty?
             next
           # strip comments
-          elsif line.start_with?("//")
+          elsif line.start_with?(comment_token)
             next
           # append rule
           else

--- a/lib/public_suffix/list.rb
+++ b/lib/public_suffix/list.rb
@@ -149,12 +149,10 @@ module PublicSuffix
     # select we can avoid mapping every single rule against the candidate domain.
     def create_index!
       @indexes = {}
-      @rules.map { |l| l.labels.first }.each_with_index do |elm, inx|
-        if !@indexes.has_key?(elm)
-          @indexes[elm] = [inx]
-        else
-          @indexes[elm] << inx
-        end
+      @rules.each_with_index do |rule, index|
+        tld = Domain.name_to_parts(rule.value).last
+        @indexes[tld] ||= []
+        @indexes[tld] << index
       end
     end
 
@@ -270,7 +268,7 @@ module PublicSuffix
     # @return [Array<PublicSuffix::Rule::*>]
     def select(name)
       name = name.to_s
-      indices = (@indexes[Domain.domain_to_labels(name).first] || [])
+      indices = (@indexes[Domain.name_to_parts(name).last] || [])
       @rules.values_at(*indices).select { |rule| rule.match?(name) }
     end
 

--- a/lib/public_suffix/list.rb
+++ b/lib/public_suffix/list.rb
@@ -103,7 +103,7 @@ module PublicSuffix
           if line.empty?
             next
           # strip comments
-          elsif line =~ %r{^//}
+          elsif line.start_with?("//")
             next
           # append rule
           else

--- a/lib/public_suffix/rule.rb
+++ b/lib/public_suffix/rule.rb
@@ -122,22 +122,6 @@ module PublicSuffix
         @labels = Domain.domain_to_labels(@value)
       end
 
-      #
-      # The rule type name.
-      #
-      # @return [Symbol]
-      #
-      def self.type
-        @type ||= self.name.split("::").last.downcase.to_sym
-      end
-
-      #
-      # @see {type}
-      #
-      def type
-        self.class.type
-      end
-
       # Checks whether this rule is equal to <tt>other</tt>.
       #
       # @param [PublicSuffix::Rule::*] other
@@ -226,12 +210,22 @@ module PublicSuffix
 
       def odiff(one, two)
         ii = 0
-
         while(ii < one.size && one[ii] == two[ii])
           ii += 1
         end
-
         one[ii..one.length]
+      end
+
+
+      # DEPRECATED
+
+      def self.type
+        # warn("deprecated")
+      end
+
+      public
+      def type
+        self.class.type
       end
 
     end

--- a/lib/public_suffix/rule.rb
+++ b/lib/public_suffix/rule.rb
@@ -246,7 +246,7 @@ module PublicSuffix
       #
       # @return [Array<String>]
       def parts
-        @parts ||= @value.split(".")
+        @parts ||= @value.split(DOT)
       end
 
       # Decomposes the domain according to rule properties.
@@ -258,7 +258,7 @@ module PublicSuffix
       #   The array with [trd + sld, tld].
       #
       def decompose(domain)
-        domain.to_s.chomp(".") =~ /^(.*)\.(#{parts.join('\.')})$/
+        domain.to_s.chomp(DOT) =~ /^(.*)\.(#{parts.join('\.')})$/
         [$1, $2]
       end
 
@@ -280,7 +280,7 @@ module PublicSuffix
       #
       # @return [Array<String>]
       def parts
-        @parts ||= @value.split(".")
+        @parts ||= @value.split(DOT)
       end
 
       # Overwrites the default implementation to cope with
@@ -300,7 +300,7 @@ module PublicSuffix
       #   The array with [trd + sld, tld].
       #
       def decompose(domain)
-        domain.to_s.chomp(".") =~ /^(.*)\.(.*?\.#{parts.join('\.')})$/
+        domain.to_s.chomp(DOT) =~ /^(.*)\.(.*?\.#{parts.join('\.')})$/
         [$1, $2]
       end
 
@@ -326,7 +326,7 @@ module PublicSuffix
       #
       # @return [Array<String>]
       def parts
-        @parts ||= @value.split(".")[1..-1]
+        @parts ||= @value.split(DOT)[1..-1]
       end
 
       # Decomposes the domain according to rule properties.
@@ -338,17 +338,12 @@ module PublicSuffix
       #   The array with [trd + sld, tld].
       #
       def decompose(domain)
-        domain.to_s.chomp(".") =~ /^(.*)\.(#{parts.join('\.')})$/
+        domain.to_s.chomp(DOT) =~ /^(.*)\.(#{parts.join('\.')})$/
         [$1, $2]
       end
 
     end
 
-    RULES = {
-      '*' => Wildcard,
-      '!' => Exception
-    }
-    RULES.default = Normal
 
     # Takes the +name+ of the rule, detects the specific rule class
     # and creates a new instance of that class.
@@ -370,7 +365,14 @@ module PublicSuffix
     #
     # @return [PublicSuffix::Rule::*] A rule instance.
     def self.factory(name)
-      RULES[name.to_s[0,1]].new(name)
+      case name.to_s[0,1]
+      when STAR
+        Wildcard
+      when BANG
+        Exception
+      else
+        Normal
+      end.new(name)
     end
 
     # The default rule to use if no rule match.
@@ -381,7 +383,7 @@ module PublicSuffix
     #
     # @return [PublicSuffix::Rule::Wildcard] The default rule.
     def self.default
-      factory("*")
+      factory(STAR)
     end
 
   end

--- a/lib/public_suffix/rule.rb
+++ b/lib/public_suffix/rule.rb
@@ -194,10 +194,7 @@ module PublicSuffix
         raise(NotImplementedError,"#{self.class}##{__method__} is not implemented")
       end
 
-      #
-      # @param [String, #to_s] domain
-      #   The domain name to decompose.
-      #
+      # @param  domain [String, #to_s] The domain name to decompose.
       # @return [Array<String, nil>]
       #
       # @raise  [NotImplementedError]
@@ -251,14 +248,10 @@ module PublicSuffix
 
       # Decomposes the domain according to rule properties.
       #
-      # @param [String, #to_s] domain
-      #   The domain name to decompose.
-      #
-      # @return [Array<String>]
-      #   The array with [trd + sld, tld].
-      #
+      # @param  domain [String, #to_s] The domain name to decompose.
+      # @return [Array<String>] The array with [trd + sld, tld].
       def decompose(domain)
-        domain.to_s.chomp(DOT) =~ /^(.*)\.(#{parts.join('\.')})$/
+        domain.to_s =~ /^(.*)\.(#{parts.join('\.')})$/
         [$1, $2]
       end
 
@@ -270,7 +263,6 @@ module PublicSuffix
       #
       # @param [String] name
       #   The name of this rule.
-      #
       def initialize(name)
         super(name, name.to_s[2..-1])
       end
@@ -293,14 +285,10 @@ module PublicSuffix
 
       # Decomposes the domain according to rule properties.
       #
-      # @param [String, #to_s] domain
-      #   The domain name to decompose.
-      #
-      # @return [Array<String>]
-      #   The array with [trd + sld, tld].
-      #
+      # @param  domain [String, #to_s] The domain name to decompose.
+      # @return [Array<String>] The array with [trd + sld, tld].
       def decompose(domain)
-        domain.to_s.chomp(DOT) =~ /^(.*)\.(.*?\.#{parts.join('\.')})$/
+        domain.to_s =~ /^(.*)\.(.*?\.#{parts.join('\.')})$/
         [$1, $2]
       end
 
@@ -311,7 +299,6 @@ module PublicSuffix
       # Initializes a new rule with +name+.
       #
       # @param  [String] name   The name of this rule.
-      #
       def initialize(name)
         super(name, name.to_s[1..-1])
       end
@@ -331,14 +318,10 @@ module PublicSuffix
 
       # Decomposes the domain according to rule properties.
       #
-      # @param [String, #to_s] domain
-      #   The domain name to decompose.
-      #
-      # @return [Array<String>]
-      #   The array with [trd + sld, tld].
-      #
+      # @param  domain [String, #to_s] The domain name to decompose.
+      # @return [Array<String>] The array with [trd + sld, tld].
       def decompose(domain)
-        domain.to_s.chomp(DOT) =~ /^(.*)\.(#{parts.join('\.')})$/
+        domain.to_s =~ /^(.*)\.(#{parts.join('\.')})$/
         [$1, $2]
       end
 

--- a/test/benchmark_helper.rb
+++ b/test/benchmark_helper.rb
@@ -1,0 +1,4 @@
+require 'benchmark'
+
+$:.unshift File.expand_path('../../lib', __FILE__)
+require 'public_suffix'

--- a/test/execution_profiler.rb
+++ b/test/execution_profiler.rb
@@ -1,0 +1,14 @@
+$:.unshift File.expand_path('../../lib', __FILE__)
+
+require 'memory_profiler'
+require 'public_suffix'
+
+list = PublicSuffix::List.default
+
+report = MemoryProfiler.report do
+    PublicSuffix.domain("www.example.com")
+    PublicSuffix.domain("a.b.ide.kyoto.jp")
+end
+
+report.pretty_print
+# report.pretty_print(to_file: 'profiler-%s-%d.txt' % [ARGV[0], Time.now.to_i])

--- a/test/initialization_profiler.rb
+++ b/test/initialization_profiler.rb
@@ -7,4 +7,5 @@ report = MemoryProfiler.report do
   PublicSuffix::List.default
 end
 
-report.pretty_print(to_file: 'profiler-%s-%d.txt' % [ARGV[0], Time.now.to_i])
+report.pretty_print
+# report.pretty_print(to_file: 'profiler-%s-%d.txt' % [ARGV[0], Time.now.to_i])

--- a/test/initialization_profiler.rb
+++ b/test/initialization_profiler.rb
@@ -7,4 +7,4 @@ report = MemoryProfiler.report do
   PublicSuffix::List.default
 end
 
-report.pretty_print
+report.pretty_print(to_file: 'profiler-%s-%d.txt' % [ARGV[0], Time.now.to_i])

--- a/test/memory_benchmark.rb
+++ b/test/memory_benchmark.rb
@@ -1,0 +1,10 @@
+$:.unshift File.expand_path('../../lib', __FILE__)
+
+require 'memory_profiler'
+require 'public_suffix'
+
+report = MemoryProfiler.report do
+  PublicSuffix::List.default
+end
+
+report.pretty_print

--- a/test/performance_benchmark.rb
+++ b/test/performance_benchmark.rb
@@ -1,0 +1,38 @@
+require_relative 'benchmark_helper'
+
+iterations = 100_000
+
+# force load
+list = PublicSuffix::List.default
+
+Benchmark.bmbm do |bm|
+  bm.report "Top level TLD" do
+    iterations.times do
+      PublicSuffix.domain("example.com", list)
+    end
+  end
+
+  bm.report "Top level TLD (subdomain)" do
+    iterations.times do
+      PublicSuffix.domain("www.example.com", list)
+    end
+  end
+
+  bm.report "Unlisted TLD" do
+    iterations.times do
+      PublicSuffix.domain("example.example", list)
+    end
+  end
+
+  bm.report "Unlisted TLD (subdomain)" do
+    iterations.times do
+      PublicSuffix.domain("www.example.example", list)
+    end
+  end
+
+  bm.report "Crazy suffix" do
+    iterations.times do
+      PublicSuffix.domain("a.b.ide.kyoto.jp", list)
+    end
+  end
+end

--- a/test/unit/domain_test.rb
+++ b/test/unit/domain_test.rb
@@ -7,25 +7,25 @@ class PublicSuffix::DomainTest < Minitest::Unit::TestCase
   end
 
   # Tokenizes given input into labels.
-  def test_self_domain_to_labels
+  def test_self_name_to_labels
     assert_equal  %w( com live spaces someone ),
-                  PublicSuffix::Domain.domain_to_labels("someone.spaces.live.com")
+                  PublicSuffix::Domain.name_to_labels("someone.spaces.live.com")
     assert_equal  %w( com zoho wiki leontina23samiko ),
-                  PublicSuffix::Domain.domain_to_labels("leontina23samiko.wiki.zoho.com")
+                  PublicSuffix::Domain.name_to_labels("leontina23samiko.wiki.zoho.com")
   end
 
   # Converts input into String.
-  def test_self_domain_to_labels_converts_input_to_string
+  def test_self_name_to_labels_converts_input_to_string
     assert_equal  %w( com live spaces someone ),
-                  PublicSuffix::Domain.domain_to_labels(:"someone.spaces.live.com")
+                  PublicSuffix::Domain.name_to_labels(:"someone.spaces.live.com")
   end
 
   # Ignores trailing .
-  def test_self_domain_to_labels_ignores_trailing_dot
+  def test_self_name_to_labels_ignores_trailing_dot
     assert_equal  %w( com live spaces someone ),
-                  PublicSuffix::Domain.domain_to_labels("someone.spaces.live.com")
+                  PublicSuffix::Domain.name_to_labels("someone.spaces.live.com")
     assert_equal  %w( com live spaces someone ),
-                  PublicSuffix::Domain.domain_to_labels(:"someone.spaces.live.com")
+                  PublicSuffix::Domain.name_to_labels(:"someone.spaces.live.com")
   end
 
 

--- a/test/unit/rule_test.rb
+++ b/test/unit/rule_test.rb
@@ -48,10 +48,10 @@ class PublicSuffix::RuleBaseTest < Minitest::Unit::TestCase
     rule = @klass.new("verona.it")
     assert_instance_of @klass,          rule
 
-    assert_equal "verona.it",           rule.name
     assert_equal "verona.it",           rule.value
     assert_equal %w(verona it).reverse, rule.labels
   end
+
 
   def test_equality_with_self
     rule = PublicSuffix::Rule::Base.new("foo")
@@ -61,6 +61,7 @@ class PublicSuffix::RuleBaseTest < Minitest::Unit::TestCase
   def test_equality_with_internals
     assert_equal      @klass.new("foo"), @klass.new("foo")
     assert_not_equal  @klass.new("foo"), @klass.new("bar")
+    assert_not_equal  @klass.new("foo"), PublicSuffix::Rule::Test.new("foo")
     assert_not_equal  @klass.new("foo"), PublicSuffix::Rule::Test.new("bar")
     assert_not_equal  @klass.new("foo"), Class.new { def name; foo; end }.new
   end
@@ -105,8 +106,8 @@ class PublicSuffix::RuleNormalTest < Minitest::Unit::TestCase
   def test_initialize
     rule = @klass.new("verona.it")
     assert_instance_of @klass,              rule
-    assert_equal "verona.it",               rule.name
     assert_equal "verona.it",               rule.value
+    assert_equal "verona.it",               rule.rule
     assert_equal %w(verona it).reverse,     rule.labels
   end
 
@@ -163,8 +164,8 @@ class PublicSuffix::RuleExceptionTest < Minitest::Unit::TestCase
   def test_initialize
     rule = @klass.new("!british-library.uk")
     assert_instance_of @klass,                    rule
-    assert_equal "!british-library.uk",           rule.name
     assert_equal "british-library.uk",            rule.value
+    assert_equal "!british-library.uk",           rule.rule
     assert_equal %w(british-library uk).reverse,  rule.labels
   end
 
@@ -214,8 +215,8 @@ class PublicSuffix::RuleWildcardTest < Minitest::Unit::TestCase
   def test_initialize
     rule = @klass.new("*.aichi.jp")
     assert_instance_of @klass,              rule
-    assert_equal "*.aichi.jp",              rule.name
     assert_equal "aichi.jp",                rule.value
+    assert_equal "*.aichi.jp",              rule.rule
     assert_equal %w(aichi jp).reverse,      rule.labels
   end
 

--- a/test/unit/rule_test.rb
+++ b/test/unit/rule_test.rb
@@ -125,22 +125,10 @@ class PublicSuffix::RuleNormalTest < Minitest::Unit::TestCase
     assert !@klass.new("go.uk").match?("example.co.uk")
   end
 
-  def test_match_with_fully_qualified_domain_name
-    assert  @klass.new("com").match?("com.")
-    assert  @klass.new("com").match?("example.com.")
-    assert  @klass.new("com").match?("www.example.com.")
-  end
-
   def test_allow
     assert !@klass.new("com").allow?("com")
     assert  @klass.new("com").allow?("example.com")
     assert  @klass.new("com").allow?("www.example.com")
-  end
-
-  def test_allow_with_fully_qualified_domain_name
-    assert !@klass.new("com").allow?("com.")
-    assert  @klass.new("com").allow?("example.com.")
-    assert  @klass.new("com").allow?("www.example.com.")
   end
 
 
@@ -160,12 +148,6 @@ class PublicSuffix::RuleNormalTest < Minitest::Unit::TestCase
     assert_equal [nil, nil], @klass.new("com").decompose("com")
     assert_equal %w( example com ), @klass.new("com").decompose("example.com")
     assert_equal %w( foo.example com ), @klass.new("com").decompose("foo.example.com")
-  end
-
-  def test_decompose_with_fully_qualified_domain_name
-    assert_equal [nil, nil], @klass.new("com").decompose("com.")
-    assert_equal %w( example com ), @klass.new("com").decompose("example.com.")
-    assert_equal %w( foo.example com ), @klass.new("com").decompose("foo.example.com.")
   end
 
 end
@@ -196,23 +178,10 @@ class PublicSuffix::RuleExceptionTest < Minitest::Unit::TestCase
     assert !@klass.new("!british-library.uk").match?("example.co.uk")
   end
 
-  def test_match_with_fully_qualified_domain_name
-    assert  @klass.new("!uk").match?("uk.")
-    assert  @klass.new("!uk").match?("co.uk.")
-    assert  @klass.new("!uk").match?("example.co.uk.")
-    assert  @klass.new("!uk").match?("www.example.co.uk.")
-  end
-
   def test_allow
     assert !@klass.new("!british-library.uk").allow?("uk")
     assert  @klass.new("!british-library.uk").allow?("british-library.uk")
     assert  @klass.new("!british-library.uk").allow?("www.british-library.uk")
-  end
-
-  def test_allow_with_fully_qualified_domain_name
-    assert !@klass.new("!british-library.uk").allow?("uk.")
-    assert  @klass.new("!british-library.uk").allow?("british-library.uk.")
-    assert  @klass.new("!british-library.uk").allow?("www.british-library.uk.")
   end
 
 
@@ -230,12 +199,6 @@ class PublicSuffix::RuleExceptionTest < Minitest::Unit::TestCase
     assert_equal [nil, nil], @klass.new("!british-library.uk").decompose("uk")
     assert_equal %w( british-library uk ), @klass.new("!british-library.uk").decompose("british-library.uk")
     assert_equal %w( foo.british-library uk ), @klass.new("!british-library.uk").decompose("foo.british-library.uk")
-  end
-
-  def test_decompose_with_fully_qualified_domain_name
-    assert_equal [nil, nil], @klass.new("!british-library.uk").decompose("uk.")
-    assert_equal %w( british-library uk ), @klass.new("!british-library.uk").decompose("british-library.uk.")
-    assert_equal %w( foo.british-library uk ), @klass.new("!british-library.uk").decompose("foo.british-library.uk.")
   end
 
 end
@@ -278,13 +241,6 @@ class PublicSuffix::RuleWildcardTest < Minitest::Unit::TestCase
     assert  @klass.new("*.uk").allow?("www.example.co.uk")
   end
 
-  def test_allow_with_fully_qualified_domain_name
-    assert !@klass.new("*.uk").allow?("uk.")
-    assert !@klass.new("*.uk").allow?("co.uk.")
-    assert  @klass.new("*.uk").allow?("example.co.uk.")
-    assert  @klass.new("*.uk").allow?("www.example.co.uk.")
-  end
-
 
   def test_length
     assert_equal 2, @klass.new("*.uk").length
@@ -300,12 +256,6 @@ class PublicSuffix::RuleWildcardTest < Minitest::Unit::TestCase
     assert_equal [nil, nil], @klass.new("*.do").decompose("nic.do")
     assert_equal %w( google co.uk ), @klass.new("*.uk").decompose("google.co.uk")
     assert_equal %w( foo.google co.uk ), @klass.new("*.uk").decompose("foo.google.co.uk")
-  end
-
-  def test_decompose_with_fully_qualified_domain_name
-    assert_equal [nil, nil], @klass.new("*.do").decompose("nic.do.")
-    assert_equal %w( google co.uk ), @klass.new("*.uk").decompose("google.co.uk.")
-    assert_equal %w( foo.google co.uk ), @klass.new("*.uk").decompose("foo.google.co.uk.")
   end
 
 end

--- a/test/unit/rule_test.rb
+++ b/test/unit/rule_test.rb
@@ -48,7 +48,6 @@ class PublicSuffix::RuleBaseTest < Minitest::Unit::TestCase
     rule = @klass.new("verona.it")
     assert_instance_of @klass,          rule
 
-    assert_equal :base,                 rule.type
     assert_equal "verona.it",           rule.name
     assert_equal "verona.it",           rule.value
     assert_equal %w(verona it).reverse, rule.labels
@@ -106,7 +105,6 @@ class PublicSuffix::RuleNormalTest < Minitest::Unit::TestCase
   def test_initialize
     rule = @klass.new("verona.it")
     assert_instance_of @klass,              rule
-    assert_equal :normal,                   rule.type
     assert_equal "verona.it",               rule.name
     assert_equal "verona.it",               rule.value
     assert_equal %w(verona it).reverse,     rule.labels
@@ -183,7 +181,6 @@ class PublicSuffix::RuleExceptionTest < Minitest::Unit::TestCase
   def test_initialize
     rule = @klass.new("!british-library.uk")
     assert_instance_of @klass,                    rule
-    assert_equal :exception,                      rule.type
     assert_equal "!british-library.uk",           rule.name
     assert_equal "british-library.uk",            rule.value
     assert_equal %w(british-library uk).reverse,  rule.labels
@@ -254,7 +251,6 @@ class PublicSuffix::RuleWildcardTest < Minitest::Unit::TestCase
   def test_initialize
     rule = @klass.new("*.aichi.jp")
     assert_instance_of @klass,              rule
-    assert_equal :wildcard,                 rule.type
     assert_equal "*.aichi.jp",              rule.name
     assert_equal "aichi.jp",                rule.value
     assert_equal %w(aichi jp).reverse,      rule.labels

--- a/test/unit/rule_test.rb
+++ b/test/unit/rule_test.rb
@@ -47,9 +47,7 @@ class PublicSuffix::RuleBaseTest < Minitest::Unit::TestCase
   def test_initialize
     rule = @klass.new("verona.it")
     assert_instance_of @klass,          rule
-
     assert_equal "verona.it",           rule.value
-    assert_equal %w(verona it).reverse, rule.labels
   end
 
 
@@ -108,7 +106,6 @@ class PublicSuffix::RuleNormalTest < Minitest::Unit::TestCase
     assert_instance_of @klass,              rule
     assert_equal "verona.it",               rule.value
     assert_equal "verona.it",               rule.rule
-    assert_equal %w(verona it).reverse,     rule.labels
   end
 
 
@@ -166,7 +163,6 @@ class PublicSuffix::RuleExceptionTest < Minitest::Unit::TestCase
     assert_instance_of @klass,                    rule
     assert_equal "british-library.uk",            rule.value
     assert_equal "!british-library.uk",           rule.rule
-    assert_equal %w(british-library uk).reverse,  rule.labels
   end
 
 
@@ -217,7 +213,6 @@ class PublicSuffix::RuleWildcardTest < Minitest::Unit::TestCase
     assert_instance_of @klass,              rule
     assert_equal "aichi.jp",                rule.value
     assert_equal "*.aichi.jp",              rule.rule
-    assert_equal %w(aichi jp).reverse,      rule.labels
   end
 
 
@@ -226,13 +221,6 @@ class PublicSuffix::RuleWildcardTest < Minitest::Unit::TestCase
     assert  @klass.new("*.uk").match?("example.co.uk")
     assert  @klass.new("*.co.uk").match?("example.co.uk")
     assert !@klass.new("*.go.uk").match?("example.co.uk")
-  end
-
-  def test_match_with_fully_qualified_domain_name
-    assert  @klass.new("*.uk").match?("uk.")
-    assert  @klass.new("*.uk").match?("co.uk.")
-    assert  @klass.new("*.uk").match?("example.co.uk.")
-    assert  @klass.new("*.uk").match?("www.example.co.uk.")
   end
 
   def test_allow


### PR DESCRIPTION
You can see the summary of the various optimization steps in each ticket. Here's an high level overview.

### Before

```
➜  publicsuffix-ruby git:(392d8a8) ✗ ruby test/initialization_profiler.rb
Total allocated: 3919924 bytes (73424 objects)
Total retained:  1962255 bytes (42857 objects)
```

```
➜  publicsuffix-ruby git:(392d8a8) ✗ ruby test/execution_profiler.rb
Total allocated: 1199594 bytes (20024 objects)
Total retained:  440 bytes (11 objects)
```

```
➜  publicsuffix-ruby git:(392d8a8) ✗ ruby test/performance_benchmark.rb
Rehearsal -------------------------------------------------------------
Top level TLD              24.760000   0.100000  24.860000 ( 25.371943)
Top level TLD (subdomain)  30.440000   0.220000  30.660000 ( 31.531124)
Unlisted TLD                2.820000   0.020000   2.840000 (  2.849041)
Unlisted TLD (subdomain)    2.730000   0.010000   2.740000 (  2.744787)
Crazy suffix              324.070000   1.590000 325.660000 (329.951073)
-------------------------------------------------- total: 386.760000sec

                                user     system      total        real
Top level TLD              26.200000   0.150000  26.350000 ( 26.628339)
Top level TLD (subdomain)  29.160000   0.150000  29.310000 ( 29.660813)
Unlisted TLD                3.720000   0.070000   3.790000 (  4.212114)
Unlisted TLD (subdomain)    3.630000   0.070000   3.700000 (  3.855816)
Crazy suffix              344.430000   2.150000 346.580000 (351.426839)
```


### After

```
➜  publicsuffix-ruby git:(benchmarks) ✗ ruby test/initialization_profiler.rb
Total allocated: 2690467 bytes (54206 objects)
Total retained:  997546 bytes (18760 objects)

➜  publicsuffix-ruby git:(benchmarks) ✗ ruby test/execution_profiler.rb
Total allocated: 44554 bytes (129 objects)
Total retained:  0 bytes (0 objects)
```

```
➜  publicsuffix-ruby git:(benchmarks) ✗ ruby test/performance_benchmark.rb
Rehearsal -------------------------------------------------------------
Top level TLD               6.110000   0.050000   6.160000 (  6.236695)
Top level TLD (subdomain)   5.900000   0.040000   5.940000 (  5.962031)
Unlisted TLD                2.750000   0.030000   2.780000 (  2.853327)
Unlisted TLD (subdomain)    2.740000   0.040000   2.780000 (  2.808530)
Crazy suffix               30.830000   0.240000  31.070000 ( 31.443836)
--------------------------------------------------- total: 48.730000sec

                                user     system      total        real
Top level TLD               6.160000   0.030000   6.190000 (  6.230126)
Top level TLD (subdomain)   6.370000   0.040000   6.410000 (  6.449061)
Unlisted TLD                2.780000   0.030000   2.810000 (  2.836781)
Unlisted TLD (subdomain)    2.580000   0.020000   2.600000 (  2.616497)
Crazy suffix               30.810000   0.250000  31.060000 ( 31.264506)
```
