### PR TITLE
allow usage under jruby for adventurous souls

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -14,8 +14,6 @@ spec = Gem::Specification.new do |s|
   s.summary           = "Domain name parser based on the Public Suffix List."
   s.description       = "PublicSuffix can parse and decompose a domain name into top level domain, domain and subdomains."
 
-  s.required_ruby_version = ">= 2.0"
-
   s.author            = "Simone Carletti"
   s.email             = "weppos@weppos.net"
   s.homepage          = "https://simonecarletti.com/code/publicsuffix-ruby"


### PR DESCRIPTION
We tried this once before (https://github.com/weppos/publicsuffix-ruby/pull/79/commits/2799594e7f6b9095756d7367e88f9261961b7a59), only the branch became polluted with other changes.  This ought to be clean.

What do you think?  Travis is configured to use jruby?  This is tested on jruby?  The gem spec prohibits jruby.

It's only that we happen to be using jruby on one project, and we'd like to get off of the fork onto the main project.