### PR TITLE
Introduce List.default_rule getter/setter, update 2.0 upgrade docs

### DIFF
--- a/2.0-Upgrade.md
+++ b/2.0-Upgrade.md
@@ -1,35 +1,50 @@
 # Welcome to PublicSuffix 2.0!
 
-PublicSuffix 2.0 contains a rewritten internal representation and comparison logic, that drastically increases the lookup performance. The new version also changes several internal and external API.
+PublicSuffix 2.0 contains a rewritten internal representation and comparison logic that drastically increases the lookup performance. It also makes a breaking change to correctly become compliant with the the official PublicSuffix algorithm, and changes several internal and external APIs.
 
-This document documents the most relevant changes to help you upgrading from PublicSuffix 1.0 to 2.0.
+The list below documents the most relevant changes to help you upgrading from PublicSuffix 1.x to 2.x:
 
-## What's New
+- The library is now 100% compliant with the official PublicSuffix algorithm. The major breaking change you may experience is that if a domain passed as input doesn't match any rule, the wildcard rule `*` is assumed. This means that unlisted TLDs will be considered valid by default, when they would have been invalid in 1.x. However, you can override this behavior to emulate the 1.x behavior if needed:
 
-- The library is now 100% compliants with the official PublicSuffix tests. The major breaking change you may experience, is that if a domain passed as input doesn't match any rule, the rule `*` is assumed. You can override this behavior by passing a custom default rule with the `default_rule` option.
-- `PublicSuffix.domain` is a new method that parses the input and returns the domain (combination of second level domain + suffix). This is a convenient helper to parse a domain name, for example when you need to determine the cookie or SSL scope.
-- Added the ability to disable the use of private domains either at runtime, in addition to the ability to not load the private domains section when reading the list (`private_domains: false`). This feature also superseded the `private_domains` class-level attribute, that is no longer available.
-
-## Upgrade
-
-When upgrading, here's the most relevant changes to keep an eye on:
-
-- Several futile utility helpers were removed, such as `Domain#rule`, `Domain#is_a_domain?`, `Domain#is_a_subdomain?`, `Domain#valid?`. You can easily obtain the same result by having a custom method that reconstructs the logic, and/or calling `PublicSuffix.{domain|parse}(domain.to_s)`.
-- `PublicSuffix::List.private_domains` is no longer available. Instead, you now have two ways to enable/disable the private domains:
-
-    1. At runtime, by using the `ignore_private` option
-    
     ```ruby
-    PublicSuffix.domain("something.blogspot.com", ignore_private: true)
+    # 1.x:
+
+    PublicSuffix.valid?("google.commm")
+    # => false
+
+    # 2.x:
+
+    PublicSuffix.valid?("google.commm")
+    # => true
+
+    PublicSuffix.valid?("google.commm", default_rule: nil)
+    # => false
+
+    PublicSuffix::List.default_rule = nil
+    PublicSuffix.valid?("google.commm")
+    # => false
     ```
 
-    1. Loading a filtered list:
+- The library adds the ability to ignore private domains either at runtime, or when parsing the list. These new options replace the `PublicSuffix::List.private_domains` class-level attribute, which is no longer available. Ignoring private domains when parsing the list is faster than doing it at runtime.
 
     ```ruby
-    # Disable support for private TLDs
-    PublicSuffix::List.default = PublicSuffix::List.parse(File.read(PublicSuffix::List::DEFAULT_LIST_PATH), private_domains: false)
+    # Default behavior:
+
+    PublicSuffix.domain("something.blogspot.com")
+    # => "something.blogspot.com
+
+    # Ignoring private domains:
+
+    # Option 1, at runtime:
+    PublicSuffix.domain("something.blogspot.com", ignore_private: true)
     # => "blogspot.com"
+
+    # Option 2, loading a filtered list:
+    PublicSuffix::List.default = PublicSuffix::List.parse(File.read(PublicSuffix::List::DEFAULT_LIST_PATH), private_domains: false)
     PublicSuffix.domain("something.blogspot.com")
     # => "blogspot.com"
     ```
 
+- The library adds a new `PublicSuffix.domain` method that parses the input and returns the domain (combination of second level domain + suffix). This is a convenient helper to parse a domain name, for example when you need to determine the cookie or SSL scope.
+
+- The library removes several redundant utility helpers, such as `Domain#rule`, `Domain#is_a_domain?`, `Domain#is_a_subdomain?`, `Domain#valid?`. You can easily obtain the same result by having a custom method that reconstructs the logic, and/or calling `PublicSuffix.{domain|parse}(domain.to_s)`.

--- a/lib/public_suffix.rb
+++ b/lib/public_suffix.rb
@@ -60,7 +60,7 @@ module PublicSuffix
   #   If domain is not a valid domain.
   # @raise [PublicSuffix::DomainNotAllowed]
   #   If a rule for +domain+ is found, but the rule doesn't allow +domain+.
-  def self.parse(name, list: List.default, default_rule: list.default_rule, ignore_private: false)
+  def self.parse(name, list: List.default, default_rule: List.default_rule, ignore_private: false)
     what = normalize(name)
     raise what if what.is_a?(DomainInvalid)
 
@@ -113,7 +113,7 @@ module PublicSuffix
   # @param  [String, #to_s] name The domain name or fully qualified domain name to validate.
   # @param  [Boolean] ignore_private
   # @return [Boolean]
-  def self.valid?(name, list: List.default, default_rule: list.default_rule, ignore_private: false)
+  def self.valid?(name, list: List.default, default_rule: List.default_rule, ignore_private: false)
     what = normalize(name)
     return false if what.is_a?(DomainInvalid)
 

--- a/lib/public_suffix/list.rb
+++ b/lib/public_suffix/list.rb
@@ -62,12 +62,30 @@ module PublicSuffix
       @default = value
     end
 
-    # Sets the default rule list to +nil+.
+    # Sets the default rule list to +nil+ and undefines the default rule if set.
     #
     # @return [self]
     def self.clear
       self.default = nil
+      remove_instance_variable(:@default_rule) if defined?(@default_rule)
       self
+    end
+
+    # Gets the default rule.
+    #
+    # @return [PublicSuffix::Rule or +nil+]
+    def self.default_rule
+      defined?(@default_rule) ? @default_rule : Rule.default
+    end
+
+    # Sets the default rule to +value+.
+    #
+    # @param [PublicSuffix::Rule or +nil+] value
+    #   The default rule.
+    #
+    # @return [PublicSuffix::Rule or +nil+]
+    def self.default_rule=(value)
+      @default_rule = value
     end
 
     # rubocop:disable Metrics/MethodLength

--- a/test/unit/list_test.rb
+++ b/test/unit/list_test.rb
@@ -177,6 +177,20 @@ EOS
     assert_equal nil, PublicSuffix::List.class_eval { @default }
   end
 
+  def test_default_rule
+    PublicSuffix::List.clear
+    assert_equal true, PublicSuffix.valid?("google.commm")
+    assert_equal false, PublicSuffix.valid?("google.commm", default_rule: nil)
+
+    PublicSuffix::List.default_rule = nil
+    assert_equal false, PublicSuffix.valid?("google.commm")
+    assert_equal true, PublicSuffix.valid?("google.commm", default_rule: PublicSuffix::Rule.default)
+
+    PublicSuffix::List.clear
+    assert_equal true, PublicSuffix.valid?("google.commm")
+    assert_equal false, PublicSuffix.valid?("google.commm", default_rule: nil)
+  end
+
   def test_self_parse
     list = PublicSuffix::List.parse(<<EOS)
 // This Source Code Form is subject to the terms of the Mozilla Public


### PR DESCRIPTION
First of all, thank you for this library, and apologies for this difficult-to-read pull request 😁 

This is a first attempt to introduce a new setting that would allow users of the library to carry on using the 1.x style behavior if needed. I found myself doing this:

```ruby
module PublicSuffix
  class List
    def default_rule
      nil
    end
  end
end
```

...and thought it worth checking in to see if you'd accept something along the lines of what I propose. 

This PR also changes the 2.0 upgrade documentation to be more clear about the breaking changes, and to provide more examples of how to maintain the preexisting 1.x behavior. It took me a while to understand what had changed between 1.x and 2.x, so I'm hoping to pass along my learnings to others. 

Please view the proposed `2.0-Upgrade.md` on its own, as opposed to reading the diff, and see `list_test.rb` for a clear example of how to use the new setting. 

Thanks for your consideration. I'm happy to work up changes if you like, and no offense if you don't like this proposal. I could work up a documentation change on its own if you prefer. 