### PR TITLE
How to get PublicSuffix 1.0 behavior

### DIFF
--- a/2.0-Upgrade.md
+++ b/2.0-Upgrade.md
@@ -6,7 +6,7 @@ This document documents the most relevant changes to help you upgrading from Pub
 
 ## What's New
 
-- The library is now 100% compliants with the official PublicSuffix tests. The major breaking change you may experience, is that if a domain passed as input doesn't match any rule, the rule `*` is assumed. You can override this behavior by passing a custom default rule with the `default_rule` option.
+- The library is now 100% compliants with the official PublicSuffix tests. The major breaking change you may experience, is that if a domain passed as input doesn't match any rule, the rule `*` is assumed. You can override this behavior by passing a custom default rule with the `default_rule` option. The old behavior can be restored by passing `default_rule: nil`.
 - `PublicSuffix.domain` is a new method that parses the input and returns the domain (combination of second level domain + suffix). This is a convenient helper to parse a domain name, for example when you need to determine the cookie or SSL scope.
 - Added the ability to disable the use of private domains either at runtime, in addition to the ability to not load the private domains section when reading the list (`private_domains: false`). This feature also superseded the `private_domains` class-level attribute, that is no longer available.
 


### PR DESCRIPTION
In https://github.com/weppos/publicsuffix-ruby/issues/110 I noticed the line

> You can enforce the library to ignore not assigned suffixes by passing a nil `default_rule`.

before I saw this I thought I had to do `default_rule: PublicSuffix::Rule.factory("!*")`, so I think it would be good to document this.