### PR TITLE
Allow default rule to be override

### DIFF
--- a/lib/public_suffix/rule.rb
+++ b/lib/public_suffix/rule.rb
@@ -357,9 +357,17 @@ module PublicSuffix
     #
     # @return [PublicSuffix::Rule::Wildcard] The default rule.
     def self.default
-      factory(STAR)
+      return @default if defined?(@default)
+      @default = factory(STAR)
     end
 
+    # Override the default rule.
+    #
+    # @param  [PublicSuffix::Rule, nil] A rule instance or nil.
+    # @return [PublicSuffix::Rule, nil] The new default rule value.
+    def self.default=(rule)
+      @default = rule
+    end
   end
 
 end

--- a/test/unit/rule_test.rb
+++ b/test/unit/rule_test.rb
@@ -31,6 +31,13 @@ class PublicSuffix::RuleTest < Minitest::Unit::TestCase
     assert_equal %w( www.example tldnotlisted ), default.decompose("www.example.tldnotlisted")
   end
 
+  def test_self_default_setter
+    default_rule_was = PublicSuffix::Rule.default
+    assert_not_equal nil, PublicSuffix::Rule.default
+    PublicSuffix::Rule.default = nil
+    assert_equal nil, PublicSuffix::Rule.default
+    PublicSuffix::Rule.default = default_rule_was
+  end
 end
 
 


### PR DESCRIPTION
It can be a bit redundant to always pass `default_rule: nil` when validating domains if your use case never needs it.