### PR TITLE
Add default excludes to .rubocop.yml

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -3,6 +3,11 @@ inherit_from:
 
 AllCops:
   Exclude:
+    # Exclude .gemspec files because they are generally auto-generated
+    - '*.gemspec'
+    # Exclude vendored folders
+    - 'tmp/**/*'
+    - 'vendor/**/*'
     # Exclude artifacts
     - 'pkg/**/*'
 


### PR DESCRIPTION
You could think that the settings here would be merged with the defaults, but rubocop doesn't seem that smart.