### PR TITLE
Fix warnings

### DIFF
--- a/test/acceptance_test.rb
+++ b/test/acceptance_test.rb
@@ -1,6 +1,6 @@
 require "test_helper"
 
-class AcceptanceTest < Minitest::Unit::TestCase
+class AcceptanceTest < Minitest::Test
 
   VALID_CASES = [
       ["example.com",             "example.com",        [nil, "example", "com"]],

--- a/test/psl_test.rb
+++ b/test/psl_test.rb
@@ -3,7 +3,7 @@ require "public_suffix"
 
 # This test runs against the current PSL file and ensures
 # the definitions satisfies the test suite.
-class PslTest < Minitest::Unit::TestCase
+class PslTest < Minitest::Test
 
   ROOT = File.expand_path("../../", __FILE__)
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -12,7 +12,7 @@ Minitest::Reporters.use! Minitest::Reporters::DefaultReporter.new(color: true)
 $LOAD_PATH.unshift File.expand_path("../../lib", __FILE__)
 require "public_suffix"
 
-Minitest::Unit::TestCase.class_eval do
+Minitest::Test.class_eval do
   unless method_exists?(:assert_not_equal)
     def assert_not_equal(exp, act, msg = nil)
       assert_operator(exp, :!=, act, msg)

--- a/test/unit/domain_test.rb
+++ b/test/unit/domain_test.rb
@@ -1,6 +1,6 @@
 require "test_helper"
 
-class PublicSuffix::DomainTest < Minitest::Unit::TestCase
+class PublicSuffix::DomainTest < Minitest::Test
 
   def setup
     @klass = PublicSuffix::Domain

--- a/test/unit/errors_test.rb
+++ b/test/unit/errors_test.rb
@@ -1,6 +1,6 @@
 require "test_helper"
 
-class ErrorsTest < Minitest::Unit::TestCase
+class ErrorsTest < Minitest::Test
 
   # Inherits from StandardError
   def test_error_inheritance

--- a/test/unit/list_test.rb
+++ b/test/unit/list_test.rb
@@ -1,6 +1,6 @@
 require "test_helper"
 
-class PublicSuffix::ListTest < Minitest::Unit::TestCase
+class PublicSuffix::ListTest < Minitest::Test
 
   def setup
     @list = PublicSuffix::List.new

--- a/test/unit/public_suffix_test.rb
+++ b/test/unit/public_suffix_test.rb
@@ -1,6 +1,6 @@
 require "test_helper"
 
-class PublicSuffixTest < Minitest::Unit::TestCase
+class PublicSuffixTest < Minitest::Test
 
   def test_private_domains_enabled_by_default
     domain = PublicSuffix.parse("www.example.blogspot.com")

--- a/test/unit/rule_test.rb
+++ b/test/unit/rule_test.rb
@@ -1,6 +1,6 @@
 require "test_helper"
 
-class PublicSuffix::RuleTest < Minitest::Unit::TestCase
+class PublicSuffix::RuleTest < Minitest::Test
 
   def test_factory_should_return_rule_normal
     rule = PublicSuffix::Rule.factory("com")
@@ -34,7 +34,7 @@ class PublicSuffix::RuleTest < Minitest::Unit::TestCase
 end
 
 
-class PublicSuffix::RuleBaseTest < Minitest::Unit::TestCase
+class PublicSuffix::RuleBaseTest < Minitest::Test
 
   class ::PublicSuffix::Rule::Test < ::PublicSuffix::Rule::Base
   end
@@ -120,7 +120,7 @@ class PublicSuffix::RuleBaseTest < Minitest::Unit::TestCase
 end
 
 
-class PublicSuffix::RuleNormalTest < Minitest::Unit::TestCase
+class PublicSuffix::RuleNormalTest < Minitest::Test
 
   def setup
     @klass = PublicSuffix::Rule::Normal
@@ -156,7 +156,7 @@ class PublicSuffix::RuleNormalTest < Minitest::Unit::TestCase
 end
 
 
-class PublicSuffix::RuleExceptionTest < Minitest::Unit::TestCase
+class PublicSuffix::RuleExceptionTest < Minitest::Test
 
   def setup
     @klass = PublicSuffix::Rule::Exception
@@ -190,7 +190,7 @@ class PublicSuffix::RuleExceptionTest < Minitest::Unit::TestCase
 end
 
 
-class PublicSuffix::RuleWildcardTest < Minitest::Unit::TestCase
+class PublicSuffix::RuleWildcardTest < Minitest::Test
 
   def setup
     @klass = PublicSuffix::Rule::Wildcard


### PR DESCRIPTION
This commit will fix these warnings:

`MiniTest::Unit::TestCase is now Minitest::Test.`