### PR TITLE
Replace name_to_labels(s).last with faster extract_tld

### DIFF
--- a/lib/public_suffix/domain.rb
+++ b/lib/public_suffix/domain.rb
@@ -27,6 +27,23 @@ module PublicSuffix
       name.to_s.split(DOT)
     end
 
+    # Returns the TLD.
+    #
+    # The input is not validated, but it is assumed to be a valid domain name.
+    #
+    # @example
+    #
+    #   extract_tld('example.com')
+    #   # => 'com'
+    #
+    #   extract_tld('example.co.uk')
+    #   # => 'uk'
+    #
+    # @param  name [String, #to_s] The domain name to extract.
+    # @return [String]
+    def self.extract_tld(name)
+      name.to_s.rpartition(DOT)[2]
+    end
 
     attr_reader :tld, :sld, :trd
 

--- a/lib/public_suffix/list.rb
+++ b/lib/public_suffix/list.rb
@@ -140,7 +140,7 @@ module PublicSuffix
     def reindex!
       @indexes = {}
       @rules.each_with_index do |rule, index|
-        tld = Domain.name_to_labels(rule.value).last
+        tld = Domain.extract_tld(rule.value)
         @indexes[tld] ||= []
         @indexes[tld] << index
       end
@@ -265,7 +265,7 @@ module PublicSuffix
     # @return [Array<PublicSuffix::Rule::*>]
     def select(name, ignore_private: false)
       name = name.to_s
-      indices = (@indexes[Domain.name_to_labels(name).last] || [])
+      indices = (@indexes[Domain.extract_tld(name)] || [])
 
       finder = @rules.values_at(*indices).lazy
       finder = finder.select { |rule| rule.match?(name) }

--- a/test/unit/domain_test.rb
+++ b/test/unit/domain_test.rb
@@ -14,6 +14,13 @@ class PublicSuffix::DomainTest < Minitest::Test
                   PublicSuffix::Domain.name_to_labels("leontina23samiko.wiki.zoho.com")
   end
 
+  def test_self_extract_tld
+    assert_equal "com", PublicSuffix::Domain.extract_tld("someone.spaces.live.com")
+    assert_equal "uk", PublicSuffix::Domain.extract_tld("foo.wiki.co.uk")
+    assert_equal "uk", PublicSuffix::Domain.extract_tld("uk")
+    assert_equal "uk", PublicSuffix::Domain.extract_tld(:"foo.wiki.co.uk")
+  end
+
   # Converts input into String.
   def test_self_name_to_labels_converts_input_to_string
     assert_equal  %w( someone spaces live com ),


### PR DESCRIPTION
Following https://github.com/weppos/publicsuffix-ruby/pull/128 I looked into `PublicSuffix::Domain.name_to_labels`'s performance.

The thing is, it's almost always used to get the TLD, so I benchmark several implementations:

```ruby
require 'benchmark/ips'

DOMAIN = 'accident-prevention.aero'
DOT = '.'
Benchmark.ips do |x|
  x.report('string.rindex + string.slice') {
    DOMAIN[(DOMAIN.rindex('.')+1..-1)]
  }
  x.report('string.rpartition') {
    DOMAIN.rpartition(DOT)[2]
  }
  x.report('split.last') {
    DOMAIN.split('.').last
  }
  x.report('string.scan') {
    DOMAIN.scan(/[^\.]+\z/).first
  }
  x.report('regexp.match') {
    /[^\.]+\z/.match(DOMAIN)[0]
  }
  x.report('string.slice') {
    DOMAIN.slice(/[^\.]+\z/)
  }
end
```

```
string.rindex + string.slice       1.710M (± 6.9%) i/s -      8.539M in   5.020714s
           string.rpartition       2.214M (± 7.7%) i/s -     11.095M in   5.044656s
                  split.last       1.716M (± 4.2%) i/s -      8.638M in   5.044117s
                 string.scan      86.526k (± 7.0%) i/s -    434.673k in   5.053164s
                regexp.match     157.309k (± 8.2%) i/s -    794.035k in   5.084998s
                string.slice     191.887k (± 4.8%) i/s -    972.379k in   5.080122s
```

So using `string.rpartition('.')[2]` is 30% faster than `string.split('.').last`.

It probably won't make a huge difference, but it might shave a few ms off the `reindex!`.

@weppos thoughts ?