### PR TITLE
Keep the index continuously updated instead of explicitly fully reindexing

### DIFF
--- a/lib/public_suffix/domain.rb
+++ b/lib/public_suffix/domain.rb
@@ -27,6 +27,23 @@ module PublicSuffix
       name.to_s.split(DOT)
     end
 
+    # Returns the TLD.
+    #
+    # The input is not validated, but it is assumed to be a valid domain name.
+    #
+    # @example
+    #
+    #   extract_tld('example.com')
+    #   # => 'com'
+    #
+    #   extract_tld('example.co.uk')
+    #   # => 'uk'
+    #
+    # @param  name [String, #to_s] The domain name to extract.
+    # @return [String]
+    def self.extract_tld(name)
+      name.to_s.rpartition(DOT)[2]
+    end
 
     attr_reader :tld, :sld, :trd
 

--- a/lib/public_suffix/list.rb
+++ b/lib/public_suffix/list.rb
@@ -103,7 +103,7 @@ module PublicSuffix
             next
 
           else
-            list.add(Rule.factory(line, private: section == 2), reindex: false)
+            list.add(Rule.factory(line, private: section == 2))
 
           end
         end
@@ -125,33 +125,9 @@ module PublicSuffix
     #
     def initialize
       @rules = []
+      @index = {}
       yield(self) if block_given?
-      reindex!
     end
-
-
-    # Creates a naive index for +@rules+. Just a hash that will tell
-    # us where the elements of +@rules+ are relative to its first
-    # {PublicSuffix::Rule::Base#labels} element.
-    #
-    # For instance if @rules[5] and @rules[4] are the only elements of the list
-    # where Rule#labels.first is 'us' @indexes['us'] #=> [5,4], that way in
-    # select we can avoid mapping every single rule against the candidate domain.
-    def reindex!
-      @indexes = {}
-      @rules.each_with_index do |rule, index|
-        tld = Domain.extract_tld(rule.value)
-        @indexes[tld] ||= []
-        @indexes[tld] << index
-      end
-    end
-
-    # Gets the naive index, a hash that with the keys being the first label of
-    # every rule pointing to an array of integers (indexes of the rules in @rules).
-    def indexes
-      @indexes.dup
-    end
-
 
     # Checks whether two lists are equal.
     #
@@ -179,17 +155,13 @@ module PublicSuffix
     #
     # @param [PublicSuffix::Rule::*] rule
     #   The rule to add to the list.
-    # @param [Boolean] reindex
-    #   Set to true to recreate the rule index
-    #   after the rule has been added to the list.
     #
     # @return [self]
     #
-    # @see #reindex!
-    #
-    def add(rule, reindex: true)
+    def add(rule)
       @rules << rule
-      reindex! if reindex
+      tld_rules = @index[Domain.extract_tld(rule.value)] ||= []
+      tld_rules << rule
       self
     end
     alias << add
@@ -213,7 +185,7 @@ module PublicSuffix
     # @return [self]
     def clear
       @rules.clear
-      reindex!
+      @index.clear
       self
     end
 
@@ -250,7 +222,7 @@ module PublicSuffix
 
     # Selects all the rules matching given domain.
     #
-    # Internally, the lookup heavily rely on the `@indexes`. The input is split into labels,
+    # Internally, the lookup heavily rely on the `@index`. The input is split into labels,
     # and we retriever from the index only the rules that end with the input label. After that,
     # a sequential scan is performed. In most cases, where the number of rules for the same label
     # is limited, this algorithm is efficient enough.
@@ -265,12 +237,8 @@ module PublicSuffix
     # @return [Array<PublicSuffix::Rule::*>]
     def select(name, ignore_private: false)
       name = name.to_s
-      indices = (@indexes[Domain.extract_tld(name)] || [])
-
-      finder = @rules.values_at(*indices).lazy
-      finder = finder.select { |rule| rule.match?(name) }
-      finder = finder.select { |rule| !rule.private } if ignore_private
-      finder.to_a
+      rules = (@index[Domain.extract_tld(name)] || [])
+      rules.select { |r| (!ignore_private || !r.private) && r.match?(name) }
     end
 
     # Gets the default rule.

--- a/lib/public_suffix/list.rb
+++ b/lib/public_suffix/list.rb
@@ -140,7 +140,7 @@ module PublicSuffix
     def reindex!
       @indexes = {}
       @rules.each_with_index do |rule, index|
-        tld = Domain.name_to_labels(rule.value).last
+        tld = Domain.extract_tld(rule.value)
         @indexes[tld] ||= []
         @indexes[tld] << index
       end
@@ -265,7 +265,7 @@ module PublicSuffix
     # @return [Array<PublicSuffix::Rule::*>]
     def select(name, ignore_private: false)
       name = name.to_s
-      indices = (@indexes[Domain.name_to_labels(name).last] || [])
+      indices = (@indexes[Domain.extract_tld(name)] || [])
 
       finder = @rules.values_at(*indices).lazy
       finder = finder.select { |rule| rule.match?(name) }

--- a/test/unit/domain_test.rb
+++ b/test/unit/domain_test.rb
@@ -14,6 +14,13 @@ class PublicSuffix::DomainTest < Minitest::Test
                   PublicSuffix::Domain.name_to_labels("leontina23samiko.wiki.zoho.com")
   end
 
+  def test_self_extract_tld
+    assert_equal "com", PublicSuffix::Domain.extract_tld("someone.spaces.live.com")
+    assert_equal "uk", PublicSuffix::Domain.extract_tld("foo.wiki.co.uk")
+    assert_equal "uk", PublicSuffix::Domain.extract_tld("uk")
+    assert_equal "uk", PublicSuffix::Domain.extract_tld(:"foo.wiki.co.uk")
+  end
+
   # Converts input into String.
   def test_self_name_to_labels_converts_input_to_string
     assert_equal  %w( someone spaces live com ),

--- a/test/unit/list_test.rb
+++ b/test/unit/list_test.rb
@@ -10,16 +10,10 @@ class PublicSuffix::ListTest < Minitest::Test
     PublicSuffix::List.clear
   end
 
-
   def test_initialize
     assert_instance_of PublicSuffix::List, @list
     assert_equal 0, @list.size
   end
-
-  def test_initialize_indexes
-    assert_equal({}, @list.indexes)
-  end
-
 
   def test_equality_with_self
     list = PublicSuffix::List.new
@@ -45,13 +39,6 @@ class PublicSuffix::ListTest < Minitest::Test
     @list << PublicSuffix::Rule.factory("net")
     assert_equal PublicSuffix::Rule.factory("com"), @list.find("google.com")
     assert_equal PublicSuffix::Rule.factory("net"), @list.find("google.net")
-  end
-
-  def test_add_should_not_duplicate_indices
-    @list = PublicSuffix::List.parse("com")
-    @list.add(PublicSuffix::Rule.factory("net"))
-
-    assert_equal @list.indexes["com"], [0]
   end
 
   def test_empty?
@@ -212,34 +199,6 @@ EOS
     assert_equal false, list.find("com").private
     assert_equal true,  list.find("blogspot.com").private
   end
-
-  def test_self_parse_indexes
-    list = PublicSuffix::List.parse(<<EOS)
-// This Source Code Form is subject to the terms of the Mozilla Public
-// License, v. 2.0. If a copy of the MPL was not distributed with this
-// file, You can obtain one at https://mozilla.org/MPL/2.0/.
-
-// ===BEGIN ICANN DOMAINS===
-
-// com
-com
-
-// uk
-*.uk
-!british-library.uk
-
-// ===END ICANN DOMAINS===
-// ===BEGIN PRIVATE DOMAINS===
-
-// Google, Inc.
-blogspot.com
-
-// ===END PRIVATE DOMAINS===
-EOS
-
-    assert_equal({ "com" => [0, 3], "uk" => [1, 2] }, list.indexes)
-  end
-
 
   private
 


### PR DESCRIPTION
Based on: https://github.com/weppos/publicsuffix-ruby/pull/129

Our initialization of PublicSuffix looks like this:

```ruby
PublicSuffix::List.default = PublicSuffix::List.parse(File.read(public_suffix_list_path), private_domains: false)
%w(orght ss).each { |tld| PublicSuffix::List.default.add(PublicSuffix::Rule.factory(tld)) }
```

Which mean that the index is built 3 times, and it takes `13ms` every time. Off course we can reduce it to 2 times by passing `reindex: false` and then call `.reindex!`, but IMO it's way simpler to have the index kept updated automatically, which is what this PR does.

It's also slightly faster overall, `PublicSuffix::List.parse(File.read(public_suffix_list_path), private_domains: false)` takes `50.0ms` on my machine with https://github.com/weppos/publicsuffix-ruby/pull/128 applied. With this patch is goes down to `42.3ms`

Of course the big issue here is that it's quite a breaking change. The `reindex!` method and the `reindex` param could be made noops that issue warnings, but there is nothing that can be done for `#indexes` since the internal structure of the index totally changed.

@weppos thoughts?