### PR TITLE
Added invalid? method, that basically returns the inverse of valid? method

### DIFF
--- a/lib/public_suffix.rb
+++ b/lib/public_suffix.rb
@@ -124,6 +124,42 @@ module PublicSuffix
     !rule.nil? && !rule.decompose(what).last.nil?
   end
 
+  # Checks whether +domain+ is non-assigned or invalid, without actually parsing it.
+  # It basically calls the `valid?` method and returns the inverse.
+  #
+  # This method doesn't care whether domain is a domain or subdomain.
+  # The validation is performed using the default {PublicSuffix::List}.
+  #
+  # @example Validate an invalid domain
+  #   PublicSuffix.invalid?(".example.com")
+  #   # => true
+  #
+  # @example Validate a valid subdomain
+  #   PublicSuffix.invalid?("www.example.com")
+  #   # => false
+  #
+  # @example Validate a not-listed domain
+  #   PublicSuffix.invalid?("example.tldnotlisted")
+  #   # => false
+  #
+  # @example Validate a fully qualified domain
+  #   PublicSuffix.invalid?("google.com.")
+  #   # => false
+  #   PublicSuffix.invalid?("www.google.com.")
+  #   # => false
+  #
+  # @example Check an URL (which is not a valid domain)
+  #   PublicSuffix.invalid?("http://www.example.com")
+  #   # => true
+  #
+  #
+  # @param  [String, #to_s] name The domain name or fully qualified domain name to validate.
+  # @param  [Boolean] ignore_private
+  # @return [Boolean]
+  def self.invalid?(name, list: List.default, default_rule: list.default_rule, ignore_private: false)
+    !valid?(name, list: List.default, default_rule: default_rule, ignore_private: ignore_private)
+  end
+
   # Attempt to parse the name and returns the domain, if valid.
   #
   # This method doesn't raise. Instead, it returns nil if the domain is not valid for whatever reason.

--- a/test/acceptance_test.rb
+++ b/test/acceptance_test.rb
@@ -27,6 +27,7 @@ class AcceptanceTest < Minitest::Test
 
       assert_equal domain, PublicSuffix.domain(input)
       assert PublicSuffix.valid?(input)
+      assert !PublicSuffix.invalid?(input)
     end
   end
 
@@ -42,6 +43,7 @@ class AcceptanceTest < Minitest::Test
     INVALID_CASES.each do |(name, error)|
       assert_raises(error) { PublicSuffix.parse(name) }
       assert !PublicSuffix.valid?(name)
+      assert PublicSuffix.invalid?(name)
     end
   end
 
@@ -63,6 +65,8 @@ class AcceptanceTest < Minitest::Test
     REJECTED_CASES.each do |name, expected|
       assert_equal expected, PublicSuffix.valid?(name),
                    "Expected %s to be %s" % [name.inspect, expected.inspect]
+      assert_equal expected, !PublicSuffix.invalid?(name),
+                   "Expected %s to be %s" % [name.inspect, expected.inspect]
       assert !valid_domain?(name),
              "#{name} expected to be invalid"
     end
@@ -83,6 +87,7 @@ class AcceptanceTest < Minitest::Test
       assert_equal sld, domain.sld, "Invalid sld for `#{name}'"
       assert_equal trd, domain.trd, "Invalid trd for `#{name}'"
       assert PublicSuffix.valid?(name)
+      assert !PublicSuffix.invalid?(name)
     end
   end
 
@@ -106,6 +111,7 @@ class AcceptanceTest < Minitest::Test
     # test valid?
     INCLUDE_PRIVATE_CASES.each do |given, ignore_private, expected|
       assert_equal !expected.nil?, PublicSuffix.valid?(given, ignore_private: ignore_private)
+      assert_equal !expected.nil?, !PublicSuffix.invalid?(given, ignore_private: ignore_private)
     end
   end
 


### PR DESCRIPTION
Very small change. For clarity of code, I needed to have an `invalid?` method, that returns the inverse of `valid?`. 

Here is the use case: 

```ruby
# wrong
invalid = whitelisted_domains_and_emails_csv.split(',').any? do |expression|
      if expression.include?('@') # Email format
        expression.match(Devise::email_regexp).nil?
      else # Domain format
        !PublicSuffix.valid?(expression)
      end
    end
```

```ruby
# good
invalid = whitelisted_domains_and_emails_csv.split(',').any? do |expression|
      if expression.include?('@') # Email format
        expression.match(Devise::email_regexp).nil?
      else # Domain format
        PublicSuffix.invalid?(expression)
      end
    end
```