### PR TITLE
Update .rubocop_defaults.yml

### DIFF
--- a/.rubocop_defaults.yml
+++ b/.rubocop_defaults.yml
@@ -168,7 +168,9 @@ Style/StringLiterals:
 
 # It's nice to be consistent. The trailing comma also allows easy reordering,
 # and doesn't cause a diff in Git when you add a line to the bottom.
-Style/TrailingCommaInLiteral:
+Style/TrailingCommaInArrayLiteral:
+  EnforcedStyleForMultiline: consistent_comma
+Style/TrailingCommaInHashLiteral:
   EnforcedStyleForMultiline: consistent_comma
 
 Style/TrivialAccessors:


### PR DESCRIPTION
@weppos This pr fixes the error I get when running `bundle exec rubocop` with this gems latest version.

```
Error: The `Style/TrailingCommaInLiteral` cop no longer exists. Please use `Style/TrailingCommaInArrayLiteral` and/or `Style/TrailingCommaInHashLiteral` instead.
```