### PR TITLE
Optimize retrieving Domain instance attributes

### DIFF
--- a/lib/public_suffix/domain.rb
+++ b/lib/public_suffix/domain.rb
@@ -85,7 +85,7 @@ module PublicSuffix
     #   # => [nil, "google", "com"]
     #
     def to_a
-      [@trd, @sld, @tld]
+      @to_a ||= [@trd, @sld, @tld]
     end
 
     # Returns the full domain name.
@@ -101,7 +101,7 @@ module PublicSuffix
     #   # => "www.google.com"
     #
     def name
-      [@trd, @sld, @tld].compact.join(DOT)
+      @name ||= to_a.compact.join(DOT)
     end
 
     # Returns a domain-like representation of this object
@@ -133,7 +133,9 @@ module PublicSuffix
     #
     # @return [String]
     def domain
-      [@sld, @tld].join(DOT) if domain?
+      return unless domain?
+
+      @domain ||= [@sld, @tld].join(DOT)
     end
 
     # Returns a subdomain-like representation of this object
@@ -165,7 +167,9 @@ module PublicSuffix
     #
     # @return [String]
     def subdomain
-      [@trd, @sld, @tld].join(DOT) if subdomain?
+      return unless subdomain?
+
+      @subdomain ||= to_a.join(DOT)
     end
 
     # Checks whether <tt>self</tt> looks like a domain.


### PR DESCRIPTION
- Reduce array allocations by replacing identical calls to `[@trd, @sld, @tld]` with instance method.
- Memoize methods to ensure computation once per `PublicSuffix::Domain` instance

## Profiler script

The following script can be used to compare allocations from current `master` and this pull request.

```ruby
# frozen_string_literal: true

$LOAD_PATH.unshift File.expand_path("../../lib", __dir__)

require "memory_profiler"
require "public_suffix"

PublicSuffix::List.default

report = MemoryProfiler.report do
  domain = PublicSuffix::Domain.new("com", "example", "wwww")
  1000.times do
    domain.to_s
    domain.domain
    domain.subdomain
  end
end

report.pretty_print
```