### PR TITLE
Fix minor typo in comment

### DIFF
--- a/lib/public_suffix/domain.rb
+++ b/lib/public_suffix/domain.rb
@@ -43,7 +43,7 @@ module PublicSuffix
     #   Initializes with a +tld+, +sld+ and +trd+.
     #   @param [String] tld The TLD (extension)
     #   @param [String] sld The SLD (domain)
-    #   @param [String] tld The TRD (subdomain)
+    #   @param [String] trd The TRD (subdomain)
     #
     # @yield [self] Yields on self.
     # @yieldparam [PublicSuffix::Domain] self The newly creates instance


### PR DESCRIPTION
`tld` should be `trd` on line 46 of domain.rb