### PR TITLE
Add email validation and tests

### DIFF
--- a/lib/public_suffix.rb
+++ b/lib/public_suffix.rb
@@ -172,6 +172,7 @@ module PublicSuffix
     return DomainInvalid.new("Name is blank") if name.empty?
     return DomainInvalid.new("Name starts with a dot") if name.start_with?(DOT)
     return DomainInvalid.new("%s is not expected to contain a scheme" % name) if name.include?("://")
+    return DomainInvalid.new("Name cannot contain an @ sign") if name.include?("@")
 
     name
   end

--- a/test/acceptance_test.rb
+++ b/test/acceptance_test.rb
@@ -38,6 +38,8 @@ class AcceptanceTest < Minitest::Test
       [nil,                       PublicSuffix::DomainInvalid],
       ["",                        PublicSuffix::DomainInvalid],
       ["  ",                      PublicSuffix::DomainInvalid],
+      ["greenmush@beemail.com",   PublicSuffix::DomainInvalid],
+      ["bish@bosh.co.uk",         PublicSuffix::DomainInvalid],
   ].freeze
 
   def test_invalid


### PR DESCRIPTION
While developing using this gem, we found a bug whereby the gem considers email addresses to be valid domains. This PR fixes that issue, disallowing @ symbols in domain/subdomains (invalid per rfc1035) via a guard clause.