### PR TITLE
Add clause disallowing invalid characters

### DIFF
--- a/lib/public_suffix.rb
+++ b/lib/public_suffix.rb
@@ -172,6 +172,7 @@ module PublicSuffix
     return DomainInvalid.new("Name is blank") if name.empty?
     return DomainInvalid.new("Name starts with a dot") if name.start_with?(DOT)
     return DomainInvalid.new("%s is not expected to contain a scheme" % name) if name.include?("://")
+    return DomainInvalid.new("%s contains invalid characters" % name) if name =~ /^[\.|-]|-.|@|\s|-$/
 
     name
   end

--- a/test/acceptance_test.rb
+++ b/test/acceptance_test.rb
@@ -34,10 +34,16 @@ class AcceptanceTest < Minitest::Test
 
 
   INVALID_CASES = [
-    ["nic.bd", PublicSuffix::DomainNotAllowed],
-    [nil,                       PublicSuffix::DomainInvalid],
-    ["",                        PublicSuffix::DomainInvalid],
-    ["  ",                      PublicSuffix::DomainInvalid],
+      ["nic.bd",                  PublicSuffix::DomainNotAllowed],
+      [nil,                       PublicSuffix::DomainInvalid],
+      ["",                        PublicSuffix::DomainInvalid],
+      ["  ",                      PublicSuffix::DomainInvalid],
+      ["google@bosh.co.uk",       PublicSuffix::DomainInvalid],
+      ["www. .com",               PublicSuffix::DomainInvalid],
+      ["-google.com",             PublicSuffix::DomainInvalid],
+      ["google-.com",             PublicSuffix::DomainInvalid],
+      ["http://google.com",       PublicSuffix::DomainInvalid],
+      [".google.com",             PublicSuffix::DomainInvalid],
   ].freeze
 
   def test_invalid
@@ -49,16 +55,8 @@ class AcceptanceTest < Minitest::Test
 
 
   REJECTED_CASES = [
-    ["www. .com", true],
     ["foo.co..uk",          true],
     ["goo,gle.com",         true],
-    ["-google.com",         true],
-    ["google-.com",         true],
-
-    # This case was covered in GH-15.
-    # I decided to cover this case because it's not easily reproducible with URI.parse
-    # and can lead to several false positives.
-    ["http://google.com",   false],
   ].freeze
 
   def test_rejected

--- a/test/acceptance_test.rb
+++ b/test/acceptance_test.rb
@@ -34,16 +34,16 @@ class AcceptanceTest < Minitest::Test
 
 
   INVALID_CASES = [
-      ["nic.bd",                  PublicSuffix::DomainNotAllowed],
-      [nil,                       PublicSuffix::DomainInvalid],
-      ["",                        PublicSuffix::DomainInvalid],
-      ["  ",                      PublicSuffix::DomainInvalid],
-      ["google@bosh.co.uk",       PublicSuffix::DomainInvalid],
-      ["www. .com",               PublicSuffix::DomainInvalid],
-      ["-google.com",             PublicSuffix::DomainInvalid],
-      ["google-.com",             PublicSuffix::DomainInvalid],
-      ["http://google.com",       PublicSuffix::DomainInvalid],
-      [".google.com",             PublicSuffix::DomainInvalid],
+    ["nic.bd",                  PublicSuffix::DomainNotAllowed],
+    [nil,                       PublicSuffix::DomainInvalid],
+    ["",                        PublicSuffix::DomainInvalid],
+    ["  ",                      PublicSuffix::DomainInvalid],
+    ["google@bosh.co.uk",       PublicSuffix::DomainInvalid],
+    ["www. .com",               PublicSuffix::DomainInvalid],
+    ["-google.com",             PublicSuffix::DomainInvalid],
+    ["google-.com",             PublicSuffix::DomainInvalid],
+    ["http://google.com",       PublicSuffix::DomainInvalid],
+    [".google.com",             PublicSuffix::DomainInvalid],
   ].freeze
 
   def test_invalid
@@ -55,8 +55,8 @@ class AcceptanceTest < Minitest::Test
 
 
   REJECTED_CASES = [
-      ["foo.co..uk", true],
-      ["goo,gle.com", true],
+    ["foo.co..uk", true],
+    ["goo,gle.com", true],
   ].freeze
 
   def test_rejected

--- a/test/acceptance_test.rb
+++ b/test/acceptance_test.rb
@@ -55,8 +55,8 @@ class AcceptanceTest < Minitest::Test
 
 
   REJECTED_CASES = [
-    ["foo.co..uk",          true],
-    ["goo,gle.com",         true],
+      ["foo.co..uk", true],
+      ["goo,gle.com", true],
   ].freeze
 
   def test_rejected


### PR DESCRIPTION
ref #164 

A simple pattern validation that rejects any characters not allowed in the RFC for domains.