### PR TITLE
Add project metadata to the gemspec

### DIFF
--- a/public_suffix.gemspec
+++ b/public_suffix.gemspec
@@ -12,6 +12,14 @@ Gem::Specification.new do |s|
   s.description = "PublicSuffix can parse and decompose a domain name into top level domain, domain and subdomains."
   s.licenses    = ["MIT"]
 
+  s.metadata = {
+    "bug_tracker_uri" => "https://github.com/weppos/publicsuffix-ruby/issues",
+    "changelog_uri" => "https://github.com/weppos/publicsuffix-ruby/blob/master/CHANGELOG.md",
+    "documentation_uri" => "https://rubydoc.info/gems/#{s.name}/#{s.version}",
+    "homepage_uri" => s.homepage,
+    "source_code_uri" => "https://github.com/weppos/publicsuffix-ruby/tree/v#{s.version}",
+  }
+
   s.required_ruby_version = ">= 2.3"
 
   s.require_paths    = ["lib"]


### PR DESCRIPTION
Add `bug_tracker_uri`, `changelog_uri`, `documentation_uri`, `homepage_uri`, and `source_code_uri` to the gemspec metadata.

These [project metadata](https://guides.rubygems.org/specification-reference/#metadata) will facilitate easy access to project information. The URI will be available on the [Rubygems project page](https://rubygems.org/gems/public_suffix), via the rubygems API, and the `gem` and `bundle` command-line tools with the next release.