### PR TITLE
Fix key duplication in codecov.yml

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -2,8 +2,6 @@
 coverage:
   precision: 1
   round: down
-
-coverage:
   status:
     project:
       default: false


### PR DESCRIPTION
This is likely to clobber the previous entries for `coverage`.