### PR TITLE
Reduce gem size

### DIFF
--- a/public_suffix.gemspec
+++ b/public_suffix.gemspec
@@ -23,7 +23,6 @@ Gem::Specification.new do |s|
   s.required_ruby_version = ">= 2.6"
 
   s.require_paths    = ["lib"]
-  s.files            = `git ls-files`.split("\n")
-  s.test_files       = `git ls-files -- {test,spec,features}/*`.split("\n")
+  s.files            = `git ls-files -z`.split("\x0").reject { |f| (File.expand_path(f) == __FILE__) || f.start_with?(*%w[bin/ test/ .git .rubocop Gemfile Rakefile]) }
   s.extra_rdoc_files = %w( LICENSE.txt )
 end


### PR DESCRIPTION
The current published gem includes test files or build files that are actually unneeded.
This change removes such files from a published gem.

In addition, this removes `test_files` from the gemspec since it is no longer supported.
See https://guides.rubygems.org/specification-reference/

Verification:

```console
$ bundle exec rake build && gem unpack pkg/*.gem
public_suffix 5.0.3 built to pkg/public_suffix-5.0.3.gem.
Unpacked gem: '/Users/masafumi.koba/git/ybiquitous/publicsuffix-ruby/public_suffix-5.0.3'

$ tree public_suffix-*
public_suffix-5.0.3/
├── .yardopts
├── 2.0-Upgrade.md
├── CHANGELOG.md
├── LICENSE.txt
├── README.md
├── SECURITY.md
├── data/
│   └── list.txt
└── lib/
    ├── public_suffix/
    │   ├── domain.rb
    │   ├── errors.rb
    │   ├── list.rb
    │   ├── rule.rb
    │   └── version.rb
    └── public_suffix.rb

4 directories, 13 files
```
