### PR TITLE
Optimise select() for long subdomains

### DIFF
--- a/lib/public_suffix/list.rb
+++ b/lib/public_suffix/list.rb
@@ -105,6 +105,7 @@ module PublicSuffix
     # @yieldparam [PublicSuffix::List] self The newly created instance.
     def initialize
       @rules = {}
+      @max_rule_size = 0
       yield(self) if block_given?
     end
 
@@ -140,6 +141,7 @@ module PublicSuffix
     # @return [self]
     def add(rule)
       @rules[rule.value] = rule_to_entry(rule)
+      @max_rule_size = [@max_rule_size, (rule.value.count DOT) + 1].max
       self
     end
     alias << add
@@ -163,6 +165,7 @@ module PublicSuffix
     # @return [self]
     def clear
       @rules.clear
+      @max_rule_size = 0
       self
     end
 
@@ -204,12 +207,14 @@ module PublicSuffix
       query = parts[index]
       rules = []
 
+      limit = [parts.size, @max_rule_size].min
+
       loop do
         match = @rules[query]
         rules << entry_to_rule(match, query) if !match.nil? && (ignore_private == false || match.private == false)
 
         index += 1
-        break if index >= parts.size
+        break if index >= limit
 
         query = parts[index] + DOT + query
       end

--- a/test/unit/public_suffix_test.rb
+++ b/test/unit/public_suffix_test.rb
@@ -7,6 +7,9 @@ class PublicSuffixTest < Minitest::Test
   def test_private_domains_enabled_by_default
     domain = PublicSuffix.parse("www.example.blogspot.com")
     assert_equal "blogspot.com", domain.tld
+
+    domain = PublicSuffix.parse("example.s3.cn-north-1.amazonaws.com.cn")
+    assert_equal "s3.cn-north-1.amazonaws.com.cn", domain.tld
   end
 
   def test_private_domains_disable


### PR DESCRIPTION
Current implementation of **select()**  searches for longest matching TLDs from the right end all the way to the left end. 

This approach is necessary to handle edge cases like **example.s3.cn-north-1.amazonaws.com.cn**, where

- **s3.cn-north-1.amazonaws.com.cn** and **com.cn** are valid.
- but the intermediates **cn-north-1.amazonaws.com.cn** and **amazonaws.com.cn** are not valid.


However, this disadvantages URLs with long subdomains like `a.very.long.subdomain.example.co.uk`.

We can terminate the search early by limiting the search size to `[parts.size, @max_rule_size].min`, where `parts.size` is number of parts in the hostname, and `@max_rule_size` is the number of parts in the largest rule in `@rules`.

#### Before

```bash
$ ruby test/benchmarks/bm_find_all.rb 1000000
Rehearsal -------------------------------------------------------------
NAME_SHORT                  2.348576   0.000000   2.348576 (  2.350146)
NAME_SHORT (noprivate)      2.444302   0.000000   2.444302 (  2.445995)
NAME_MEDIUM                 2.890648   0.000000   2.890648 (  2.892380)
NAME_MEDIUM (noprivate)     3.014823   0.000000   3.014823 (  3.017137)
NAME_LONG                   3.705042   0.002693   3.707735 (  3.710142)
NAME_LONG (noprivate)       3.727960   0.000000   3.727960 (  3.730321)
NAME_WILD                   3.657520   0.000000   3.657520 (  3.659759)
NAME_WILD (noprivate)       3.815247   0.000000   3.815247 (  3.817492)
NAME_EXCP                   4.420996   0.000000   4.420996 (  4.423570)
NAME_EXCP (noprivate)       4.408350   0.000000   4.408350 (  4.411540)
IAAA                        2.604410   0.000000   2.604410 (  2.605894)
IAAA (noprivate)            2.688674   0.000000   2.688674 (  2.690398)
IZZZ                        2.605931   0.000000   2.605931 (  2.607543)
IZZZ (noprivate)            2.679484   0.000000   2.679484 (  2.681334)
PAAA                        4.506107   0.000000   4.506107 (  4.509242)
PAAA (noprivate)            4.174697   0.000000   4.174697 (  4.177737)
PZZZ                        4.618712   0.000000   4.618712 (  4.622306)
PZZZ (noprivate)            4.323496   0.000000   4.323496 (  4.327372)
JP                          4.151477   0.000000   4.151477 (  4.154904)
JP (noprivate)              4.230317   0.000000   4.230317 (  4.234143)
IT                          2.645423   0.000000   2.645423 (  2.647490)
IT (noprivate)              2.731147   0.000000   2.731147 (  2.733281)
COM                         2.672895   0.000000   2.672895 (  2.675236)
COM (noprivate)             2.796167   0.000000   2.796167 (  2.798951)
--------------------------------------------------- total: 81.865094sec

                                user     system      total        real
NAME_SHORT                  2.455661   0.000000   2.455661 (  2.458051)
NAME_SHORT (noprivate)      2.465275   0.000000   2.465275 (  2.468431)
NAME_MEDIUM                 2.946424   0.000000   2.946424 (  2.949358)
NAME_MEDIUM (noprivate)     3.023296   0.000000   3.023296 (  3.025300)
NAME_LONG                   3.770850   0.000000   3.770850 (  3.773397)
NAME_LONG (noprivate)       3.828416   0.000000   3.828416 (  3.830904)
NAME_WILD                   3.749617   0.000000   3.749617 (  3.752038)
NAME_WILD (noprivate)       3.827687   0.000000   3.827687 (  3.830190)
NAME_EXCP                   4.418445   0.000000   4.418445 (  4.421315)
NAME_EXCP (noprivate)       4.531002   0.000000   4.531002 (  4.535273)
IAAA                        2.699374   0.000000   2.699374 (  2.700931)
IAAA (noprivate)            2.768779   0.000000   2.768779 (  2.771347)
IZZZ                        2.699160   0.000000   2.699160 (  2.702339)
IZZZ (noprivate)            2.766278   0.000000   2.766278 (  2.769706)
PAAA                        4.706753   0.000000   4.706753 (  4.711835)
PAAA (noprivate)            4.363877   0.000000   4.363877 (  4.367030)
PZZZ                        4.716710   0.000000   4.716710 (  4.722447)
PZZZ (noprivate)            4.109007   0.000000   4.109007 (  4.111433)
JP                          3.937950   0.000000   3.937950 (  3.941688)
JP (noprivate)              4.065472   0.000000   4.065472 (  4.070663)
IT                          2.628695   0.000000   2.628695 (  2.630612)
IT (noprivate)              2.718972   0.000000   2.718972 (  2.721554)
COM                         2.647181   0.000000   2.647181 (  2.649369)
COM (noprivate)             2.714115   0.000000   2.714115 (  2.715725)
```

#### After

```bash
$ ruby test/benchmarks/bm_find_all.rb 1000000
Rehearsal -------------------------------------------------------------
NAME_SHORT                  2.371768   0.000000   2.371768 (  2.373272)
NAME_SHORT (noprivate)      2.433509   0.000000   2.433509 (  2.435165)
NAME_MEDIUM                 2.923829   0.000000   2.923829 (  2.925493)
NAME_MEDIUM (noprivate)     3.033018   0.000000   3.033018 (  3.034805)
NAME_LONG                   3.286291   0.000000   3.286291 (  3.288275)
NAME_LONG (noprivate)       3.296587   0.000000   3.296587 (  3.298577)
NAME_WILD                   3.243654   0.000000   3.243654 (  3.245537)
NAME_WILD (noprivate)       3.341481   0.000000   3.341481 (  3.343623)
NAME_EXCP                   3.961445   0.000000   3.961445 (  3.963717)
NAME_EXCP (noprivate)       4.087874   0.000000   4.087874 (  4.090172)
IAAA                        2.618966   0.000000   2.618966 (  2.620466)
IAAA (noprivate)            2.680218   0.000000   2.680218 (  2.681846)
IZZZ                        2.635564   0.000000   2.635564 (  2.637223)
IZZZ (noprivate)            2.688494   0.000000   2.688494 (  2.690149)
PAAA                        3.847691   0.000000   3.847691 (  3.850179)
PAAA (noprivate)            3.499989   0.000000   3.499989 (  3.501865)
PZZZ                        3.914541   0.000000   3.914541 (  3.916828)
PZZZ (noprivate)            3.568083   0.000000   3.568083 (  3.570217)
JP                          4.055892   0.000000   4.055892 (  4.058222)
JP (noprivate)              4.185491   0.000000   4.185491 (  4.187982)
IT                          2.754795   0.000000   2.754795 (  2.756420)
IT (noprivate)              2.812259   0.000000   2.812259 (  2.813942)
COM                         2.618668   0.000000   2.618668 (  2.620033)
COM (noprivate)             2.674763   0.000000   2.674763 (  2.676298)
--------------------------------------------------- total: 76.534870sec

                                user     system      total        real
NAME_SHORT                  2.390744   0.000000   2.390744 (  2.391978)
NAME_SHORT (noprivate)      2.450554   0.000000   2.450554 (  2.451912)
NAME_MEDIUM                 2.926200   0.000000   2.926200 (  2.927758)
NAME_MEDIUM (noprivate)     3.006650   0.000000   3.006650 (  3.008476)
NAME_LONG                   3.272279   0.000000   3.272279 (  3.274021)
NAME_LONG (noprivate)       3.341959   0.000000   3.341959 (  3.343897)
NAME_WILD                   3.277551   0.000000   3.277551 (  3.279307)
NAME_WILD (noprivate)       3.344168   0.000000   3.344168 (  3.346123)
NAME_EXCP                   3.931826   0.000000   3.931826 (  3.934074)
NAME_EXCP (noprivate)       3.992941   0.000000   3.992941 (  3.995389)
IAAA                        2.660274   0.000000   2.660274 (  2.661631)
IAAA (noprivate)            2.732888   0.000000   2.732888 (  2.734457)
IZZZ                        2.683949   0.000000   2.683949 (  2.685390)
IZZZ (noprivate)            2.782340   0.000000   2.782340 (  2.783906)
PAAA                        3.919312   0.000000   3.919312 (  3.921531)
PAAA (noprivate)            3.579776   0.000000   3.579776 (  3.581754)
PZZZ                        3.960433   0.000000   3.960433 (  3.962891)
PZZZ (noprivate)            3.634914   0.000000   3.634914 (  3.636953)
JP                          4.119541   0.000000   4.119541 (  4.121808)
JP (noprivate)              4.264026   0.000000   4.264026 (  4.266450)
IT                          2.643259   0.000000   2.643259 (  2.644652)
IT (noprivate)              2.693806   0.000000   2.693806 (  2.695252)
COM                         2.660541   0.000000   2.660541 (  2.662161)
COM (noprivate)             2.697171   0.000000   2.697171 (  2.698609)
```