### PR TITLE
Add funding_uri to gemspec

### DIFF
--- a/public_suffix.gemspec
+++ b/public_suffix.gemspec
@@ -20,6 +20,7 @@ Gem::Specification.new do |s|
     "documentation_uri" => "https://rubydoc.info/gems/#{s.name}/#{s.version}",
     "homepage_uri" => s.homepage,
     "source_code_uri" => "https://github.com/weppos/publicsuffix-ruby/tree/v#{s.version}",
+    "funding_uri" => "https://github.com/sponsors/weppos",
   }
 
   s.files = Dir.chdir(__dir__) do


### PR DESCRIPTION
I noticed that the project already has a FUNDING.yml. This PR adds the `funding_uri` to your gemspec to help increase visibility using the `bundle fund` command in Bundler.