### PR TITLE
fix: Year of 2025 releases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,7 +43,7 @@
 - Updated definitions.
 
 
-## 7.0.0 - 2024-11-17
+## 7.0.0 - 2025-11-17
 
 ### Changed
 
@@ -51,7 +51,7 @@
 - Minimum Ruby version is 3.2
 
 
-## 6.0.2 - 2024-04-30
+## 6.0.2 - 2025-04-30
 
 ### Changed
 


### PR DESCRIPTION
The versions 6.0.2 and 7.0.0 were released in 2025 according to the releases on RubyGems.org and the git tags on GitHub. This pull request fixes the dates of the releases in the changelog.

- RubyGems
  - [6.0.2](https://rubygems.org/gems/public_suffix/versions/6.0.2)
  - [7.0.0](https://rubygems.org/gems/public_suffix/versions/7.0.0)
- git tags on GitHub
  - [v6.0.2](https://github.com/weppos/publicsuffix-ruby/releases/tag/v6.0.2)
  - [v7.0.0](https://github.com/weppos/publicsuffix-ruby/releases/tag/v7.0.0)