### PR TITLE
fix: Adjust links to branch renaming

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,7 +200,7 @@ No. `PublicSuffix` comes with a bundled list. It does not make any HTTP requests
 
 ### Documentation
 
-Library documentation is auto-generated from the [README](https://github.com/weppos/publicsuffix-ruby/blob/master/README.md) and source code, and is available at https://rubydoc.info/gems/public_suffix.
+Library documentation is auto-generated from the [README](https://github.com/weppos/publicsuffix-ruby/blob/main/README.md) and source code, and is available at https://rubydoc.info/gems/public_suffix.
 
 ### Bug reports and contributions
 

--- a/public_suffix.gemspec
+++ b/public_suffix.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
 
   s.metadata = {
     "bug_tracker_uri" => "https://github.com/weppos/publicsuffix-ruby/issues",
-    "changelog_uri" => "https://github.com/weppos/publicsuffix-ruby/blob/master/CHANGELOG.md",
+    "changelog_uri" => "https://github.com/weppos/publicsuffix-ruby/blob/main/CHANGELOG.md",
     "documentation_uri" => "https://rubydoc.info/gems/#{s.name}/#{s.version}",
     "homepage_uri" => s.homepage,
     "source_code_uri" => "https://github.com/weppos/publicsuffix-ruby/tree/v#{s.version}",


### PR DESCRIPTION
The default branch was renamed from 'master' to 'main'.