### PR TITLE
Fix Wildcard#match? matching a wildcard rule against its own value

### DIFF
--- a/lib/public_suffix/rule.rb
+++ b/lib/public_suffix/rule.rb
@@ -241,6 +241,21 @@ module PublicSuffix
         value == "" ? STAR : STAR + DOT + value
       end
 
+      # Checks if this rule matches +name+.
+      #
+      # Unlike {Base#match?}, an exact match against +value+ is not enough,
+      # because the wildcard label requires an additional leading label
+      # to be present in +name+. For example, "*.com" doesn't match "com",
+      # only names with at least one label before it (e.g. "example.com").
+      #
+      # @param  name [String] the domain name to check
+      # @return [Boolean]
+      def match?(name)
+        return super if value == ""
+
+        name.chomp(value).end_with?(DOT)
+      end
+
       # Decomposes the domain name according to rule properties.
       #
       # @param  domain [#to_s] The domain name to decompose

--- a/test/unit/rule_test.rb
+++ b/test/unit/rule_test.rb
@@ -89,10 +89,11 @@ class PublicSuffix::RuleBaseTest < Minitest::Test
 
   def test_match_wildcard_and_exception
     [
-      # FIXME
-      # [PublicSuffix::Rule.factory("*.com"), "com", false],
+      [PublicSuffix::Rule.factory("*.com"), "com", false],
       [PublicSuffix::Rule.factory("*.com"), "example.com", true],
       [PublicSuffix::Rule.factory("*.com"), "foo.example.com", true],
+      [PublicSuffix::Rule.factory("*.co.uk"), "co.uk", false],
+      [PublicSuffix::Rule.factory("*.co.uk"), "example.co.uk", true],
       [PublicSuffix::Rule.factory("!example.com"), "com", false],
       [PublicSuffix::Rule.factory("!example.com"), "example.com", true],
       [PublicSuffix::Rule.factory("!example.com"), "foo.example.com", true],
@@ -241,6 +242,18 @@ class PublicSuffix::RuleWildcardTest < Minitest::Test
   def test_parts
     assert_equal %w[uk], @klass.build("*.uk").parts
     assert_equal %w[co uk], @klass.build("*.co.uk").parts
+  end
+
+  def test_match
+    # the wildcard label requires an extra leading label in the input,
+    # so the rule's own value alone must not match
+    [
+      ["uk", false],
+      ["google.uk", true],
+      ["foo.google.uk", true],
+    ].each do |input, expected|
+      assert_equal expected, @klass.build("*.uk").match?(input)
+    end
   end
 
   def test_decompose


### PR DESCRIPTION
`*.com`'s `match?` should only be true for names with at least one label before `com` (that's what the wildcard is for), but `Rule::Base#match?` treats an exact match against `value` as a hit too, so `match?("com")` for the `*.com` rule comes back `true` - same as a plain `com` rule would. There's even a commented-out FIXME test for exactly this in rule_test.rb already.

`decompose`/the actual parsing pipeline aren't affected since they use their own regex, but `match?` is a documented public method and gives the wrong answer if you call it directly on a wildcard rule.

Added an override in `Wildcard` that requires the extra label, uncommented the FIXME'd test case and added a couple more (multi-label wildcard value, plus a dedicated `test_match` in `RuleWildcardTest`).